### PR TITLE
Made "Shitpost" flair relay into discord at Sultan's request

### DIFF
--- a/cogs/lifecycle/check_reddit.py
+++ b/cogs/lifecycle/check_reddit.py
@@ -36,7 +36,7 @@ async def check_reddit(bot: commands.Bot):
     redditChannel = cast(TextChannel, bot.get_channel(hc_constants.REDDIT_CHANNEL))
     messagesInLastDay = [mess async for mess in redditChannel.history(after=oneHour)]
 
-    async for submission in hellscubeSubreddit.search('flair:"Card Idea" OR flair:"HellsCube Submission" OR flair:"Brainstorming"', time_filter="hour"):  # type: ignore
+    async for submission in hellscubeSubreddit.search('flair:"Card Idea" OR flair:"HellsCube Submission" OR flair:"Brainstorming" OR "Hellscube Would Love This (Shitpost)"', time_filter="hour"):  # type: ignore
         #  print(messagesInLastDay.__len__(), submission.permalink)
         alreadyPosted = False
         for discordMessage in messagesInLastDay:
@@ -45,8 +45,12 @@ async def check_reddit(bot: commands.Bot):
                 break
 
         if not alreadyPosted:
+            if submission.link_flair_text == "Hellscube Would Love This (Shitpost)":
+                message_prefix = "Reddit thinks Hellscube would love this:"
+            else:
+                message_prefix = "reddit says:"
             await redditChannel.send(
-                content=f"reddit says: https://reddit.com{submission.permalink}"
+                content=f"{message_prefix} https://reddit.com{submission.permalink}"
             )
     await reddit.close()
     return


### PR DESCRIPTION
Brainstorming flair already did this, now shitposting has a message too. 

I'm intentionally leaving the past flairs too in case of some renaming of flairs, future proofing at least one thing not breaking. Or in the unlikely case we ever go back to accepting cards from reddit, like a shitpost cube. I can remove them if wanted.