### PR TITLE
Fix Reddit gallery posts after asyncpraw 7.8.x upgrade

### DIFF
--- a/reddit_functions.py
+++ b/reddit_functions.py
@@ -1,7 +1,9 @@
 import os
-from typing import Dict, List
+from typing import Dict, List, Union
 
 import asyncpraw
+from asyncpraw.const import API_PATH
+from asyncpraw.exceptions import RedditAPIException
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -30,6 +32,14 @@ async def post_to_reddit(image_path: str, title: str, flair: str = ""):
         )
 
 
+def _gallery_media_id(upload_result: Union[str, tuple]) -> str:
+    # asyncpraw 7.7.x returns (asset_id, websocket_url); 7.8.x returns asset_id only.
+    # submit_gallery still indexes [0], which breaks on 7.8.x (first char of the id).
+    if isinstance(upload_result, tuple):
+        return upload_result[0]
+    return upload_result
+
+
 async def post_gallery_to_reddit(
     images: List[Dict[str, str]], title: str, flair: str = ""
 ):
@@ -40,10 +50,41 @@ async def post_gallery_to_reddit(
         user_agent=USER_AGENT,
         username=NAME,
     ) as reddit:
-        # print(await reddit.user.me())
         hellscubeSubreddit: asyncpraw.reddit.Subreddit = await reddit.subreddit(
             "HellsCube"
         )
-        await hellscubeSubreddit.submit_gallery(
-            title=title, images=images, flair_id=flair
+        hellscubeSubreddit._validate_gallery(images)
+        data = {
+            "api_type": "json",
+            "items": [],
+            "nsfw": False,
+            "sendreplies": True,
+            "show_error_list": True,
+            "spoiler": False,
+            "sr": str(hellscubeSubreddit),
+            "title": title,
+            "validate_on_submit": reddit.validate_on_submit,
+        }
+        if flair:
+            data["flair_id"] = flair
+        for image in images:
+            media_id = _gallery_media_id(
+                await hellscubeSubreddit._upload_media(
+                    expected_mime_prefix="image",
+                    media_path=image["image_path"],
+                    upload_type="gallery",
+                )
+            )
+            data["items"].append(
+                {
+                    "caption": image.get("caption", ""),
+                    "outbound_url": image.get("outbound_url", ""),
+                    "media_id": media_id,
+                }
+            )
+        response = await reddit.request(
+            json=data, method="POST", path=API_PATH["submit_gallery_post"]
         )
+        response = response["json"]
+        if response["errors"]:
+            raise RedditAPIException(response["errors"])


### PR DESCRIPTION
## Summary
- Fixes daily submissions gallery posts failing on `main`/production after the asyncpraw 7.8.1 upgrade (`INVALID_MEDIA_ASSETS: All Media assets must be owned by the submitter`)
- Work around asyncpraw 7.8.x bug where `submit_gallery` indexes `[0]` on a string asset id, sending only the first character as `media_id`
- Upload gallery images and submit the post directly in `post_gallery_to_reddit`, normalizing tuple vs string upload results for 7.7.x/7.8.x compatibility

## Test plan
- [ ] Merge and deploy to lil-mork
- [ ] Confirm daily submissions gallery post succeeds
- [ ] Confirm single-image `post_to_reddit` still works