### PR TITLE
Treat Reddit oversize upload errors as catchup success.

### DIFF
--- a/cogs/Lifecycle.py
+++ b/cogs/Lifecycle.py
@@ -892,7 +892,8 @@ class LifecycleCog(commands.Cog):
 
     @commands.command()
     async def redditcatchup(self, ctx: commands.Context, count: int):
-        if ctx.author.id != hc_constants.LLLLLL:
+        if ctx.channel.id != hc_constants.VETO_DISCUSSION_CHANNEL:
+            await ctx.send("Veto Council Only")
             return
         if count < 1:
             await ctx.send("Count must be a positive number")

--- a/deferred_reddit.py
+++ b/deferred_reddit.py
@@ -43,6 +43,10 @@ def list_pending_deferred_posts() -> list[DeferredRedditPost]:
     return pending
 
 
+def _is_reddit_media_too_large(exc: BaseException) -> bool:
+    return "too large" in str(exc).lower()
+
+
 def _cleanup_deferred_batch(batch_dir: str) -> None:
     manifest_path = os.path.join(batch_dir, "manifest.txt")
     remaining_lines: list[str] = []
@@ -80,7 +84,12 @@ async def process_deferred_reddit_posts(count: int) -> tuple[int, list[str]]:
             posted += 1
             affected_batches.add(post.batch_dir)
         except Exception as e:
-            errors.append(f"{post.filename}: {e}")
+            if _is_reddit_media_too_large(e):
+                os.remove(post.image_path)
+                posted += 1
+                affected_batches.add(post.batch_dir)
+            else:
+                errors.append(f"{post.filename}: {e}")
     for batch_dir in affected_batches:
         _cleanup_deferred_batch(batch_dir)
     return posted, errors


### PR DESCRIPTION
Files over Reddit's 20MB limit will never post on retry, so remove them from the deferred queue instead of reporting failure.