### PR TITLE
Post compileveto announcements to veto hellpits

### DIFF
--- a/cogs/Lifecycle.py
+++ b/cogs/Lifecycle.py
@@ -42,6 +42,7 @@ from getters import (
     getSubmissionDiscussionChannel,
     getVetoChannel,
     getVetoDiscussionChannel,
+    getVetoHellpitsChannel,
 )
 from handleVetoPost import handleVetoPost
 import hc_constants
@@ -1117,9 +1118,9 @@ class LifecycleCog(commands.Cog):
             except:
                 print(f"ERROR: unable to process: {messageEntry.content}")
 
-        vetoDiscussionChannel = getVetoDiscussionChannel(self.bot)
+        vetoAnnouncementChannel = getVetoHellpitsChannel(self.bot)
 
-        await vetoDiscussionChannel.send(
+        await vetoAnnouncementChannel.send(
             content=f"!! VETO POLLS HAVE BEEN PROCESSED !!"
         )
 
@@ -1129,7 +1130,7 @@ class LifecycleCog(commands.Cog):
                 "\n".join(acceptedCards)
             )
             for i in range(0, acceptedMessage.__len__(), hc_constants.LITERALLY_1984):
-                await vetoDiscussionChannel.send(
+                await vetoAnnouncementChannel.send(
                     content=acceptedMessage[i : i + hc_constants.LITERALLY_1984]
                 )
         if len(needsErrataCards) > 0:
@@ -1137,13 +1138,13 @@ class LifecycleCog(commands.Cog):
                 "\n".join(needsErrataCards)
             )
             for i in range(0, errataMessage.__len__(), hc_constants.LITERALLY_1984):
-                await vetoDiscussionChannel.send(
+                await vetoAnnouncementChannel.send(
                     content=errataMessage[i : i + hc_constants.LITERALLY_1984]
                 )
         if len(vetoedCards) > 0:
             vetoMessage = "||\u200b||\nVETOED: \n{0}".format("\n".join(vetoedCards))
             for i in range(0, vetoMessage.__len__(), hc_constants.LITERALLY_1984):
-                await vetoDiscussionChannel.send(
+                await vetoAnnouncementChannel.send(
                     content=vetoMessage[i : i + hc_constants.LITERALLY_1984]
                 )
         if len(vetoHellCards) > 0:
@@ -1151,7 +1152,7 @@ class LifecycleCog(commands.Cog):
                 "\n".join(vetoHellCards)
             )
             for i in range(0, hellMessage.__len__(), hc_constants.LITERALLY_1984):
-                await vetoDiscussionChannel.send(
+                await vetoAnnouncementChannel.send(
                     content=hellMessage[i : i + hc_constants.LITERALLY_1984]
                 )
         if len(mysteryVetoHellCards) > 0:
@@ -1161,7 +1162,7 @@ class LifecycleCog(commands.Cog):
             for i in range(
                 0, mysteryHellMessage.__len__(), hc_constants.LITERALLY_1984
             ):
-                await vetoDiscussionChannel.send(
+                await vetoAnnouncementChannel.send(
                     content=mysteryHellMessage[i : i + hc_constants.LITERALLY_1984]
                 )
 

--- a/getters.py
+++ b/getters.py
@@ -47,3 +47,7 @@ def getMorkSubmissionsLoggingChannel(bot: commands.Bot):
 
 def getVetoDiscussionChannel(bot: commands.Bot):
     return cast(TextChannel, bot.get_channel(hc_constants.VETO_DISCUSSION_CHANNEL))
+
+
+def getVetoHellpitsChannel(bot: commands.Bot):
+    return cast(TextChannel, bot.get_channel(hc_constants.VETO_HELLPITS))


### PR DESCRIPTION
## Summary
- Route `compileveto` result announcements (processed banner, accepted/vetoed/hell lists) to `VETO_HELLPITS` instead of `VETO_DISCUSSION_CHANNEL`.
- Add `getVetoHellpitsChannel()` helper; council commands still run from veto discussion.

## Test plan
- [ ] Run `compileveto` from veto discussion and confirm summary posts appear in veto hellpits (`1242640978360274994`), not veto discussion.
- [ ] Confirm accepted/vetoed/hell card lists still split correctly for long messages.


Made with [Cursor](https://cursor.com)