### PR TITLE
Split card messages on last " by " delimiter

### DIFF
--- a/cogs/Lifecycle.py
+++ b/cogs/Lifecycle.py
@@ -30,7 +30,7 @@ from cogs.HellscubeDatabase import get_card_by_id, get_card_by_name, searchFor
 from cogs.lifecycle.check_reddit import check_reddit
 from cogs.lifecycle.post_daily_submissions import post_daily_submissions
 from cogs.lifecycle.submissions_day_markers import ensure_submissions_day_marker
-from getCardMessage import getCardMessage
+from getCardMessage import getCardMessage, parseCardNameAndAuthor
 from getVetoPollsResults import (
     VetoPollResults,
     getVetoPollsResults,
@@ -368,20 +368,7 @@ class LifecycleCog(commands.Cog):
             file = await message.attachments[0].to_file()
             acceptanceMessage = message.content
             # consider putting most of this into acceptCard
-            # this is pretty much the same as getCardMessage but teasing out the db logic too was gonna suck
-            dbname = ""
-            card_author = ""
-            if (len(acceptanceMessage)) == 0 or "by " not in acceptanceMessage:
-                ...  # This is really the case of setting both to "", but due to scoping i got lazy
-            elif acceptanceMessage[0:3] == "by ":
-                card_author = str((acceptanceMessage.split("by "))[1])
-            else:
-                messageChunks = acceptanceMessage.split(" by ")
-                firstPart = messageChunks[0]
-                secondPart = "".join(messageChunks[1:])
-
-                dbname = str(firstPart)
-                card_author = str(secondPart)
+            dbname, card_author = parseCardNameAndAuthor(acceptanceMessage)
             resolvedName = dbname if dbname != "" else "Crazy card with no name"
             resolvedAuthor = card_author if card_author != "" else "no author"
             cardMessage = f"**{resolvedName}** by **{resolvedAuthor}**"
@@ -964,8 +951,6 @@ class LifecycleCog(commands.Cog):
             acceptanceMessage = messageEntry.content
             # consider putting most of this into acceptCard
             # errata format: first line "cardname by author", second line "Errata: card_id"
-            dbname = ""
-            card_author = ""
             errataLinens = acceptanceMessage.splitlines()
             errata_id = (
                 errataLinens[1].strip().removeprefix("Errata: ").strip()
@@ -973,16 +958,7 @@ class LifecycleCog(commands.Cog):
                 else None
             )
             first_line = errataLinens[0] if errataLinens else ""
-            if (len(first_line)) == 0 or " by " not in first_line:
-                ...
-            elif first_line[0:3] == "by ":
-                card_author = str((first_line.split(" by ", 1))[1])
-            else:
-                messageChunks = first_line.split(" by ", 1)
-                firstPart = messageChunks[0].strip()
-                secondPart = messageChunks[1] if len(messageChunks) > 1 else ""
-                dbname = str(firstPart)
-                card_author = str(secondPart)
+            dbname, card_author = parseCardNameAndAuthor(first_line)
             card_author = card_author.strip()
             # Resolve display name from card id (errata messages use id on first line)
             errata_card = get_card_by_id(errata_id) if errata_id else None
@@ -1028,19 +1004,7 @@ class LifecycleCog(commands.Cog):
             print(f"cvV processing {messageEntry.content}")
 
             acceptanceMessage = messageEntry.content
-            dbname = ""
-            card_author = ""
-            if (len(acceptanceMessage)) == 0 or "by " not in acceptanceMessage:
-                ...
-            elif acceptanceMessage[0:3] == "by ":
-                card_author = str((acceptanceMessage.split("by "))[1])
-            else:
-                messageChunks = acceptanceMessage.split(" by ")
-                firstPart = messageChunks[0]
-                secondPart = "".join(messageChunks[1:])
-
-                dbname = str(firstPart)
-                card_author = str(secondPart)
+            dbname, card_author = parseCardNameAndAuthor(acceptanceMessage)
             resolvedName = dbname if dbname != "" else "Crazy card with no name"
             resolvedAuthor = card_author if card_author != "" else "no author"
             cardMessage = f"**{resolvedName}** by **{resolvedAuthor}**"
@@ -1202,12 +1166,7 @@ class LifecycleCog(commands.Cog):
             await ctx.send("Please include a card ID on the first line.")
             return
         else:
-            messageChunks = cardMessage.split(" by ")
-            firstPart = messageChunks[0]
-            secondPart = "".join(messageChunks[1:])
-
-            dbname = str(firstPart)
-            card_author = str(secondPart)
+            dbname, card_author = parseCardNameAndAuthor(cardMessage)
 
         errata_id_clean = errataId.removeprefix("Errata: ").strip()
         db_card = get_card_by_id(errata_id_clean)

--- a/cogs/Misc.py
+++ b/cogs/Misc.py
@@ -11,6 +11,7 @@ from cogs.HellscubeDatabase import searchFor
 
 authorSplit = "$#$#$"
 QUOTE_SPLIT = ";%;%;"
+from getCardMessage import parseCardNameAndAuthor
 from handleVetoPost import handleVetoPost
 from isRealCard import isRealCard
 from printCardImages import send_image_reply
@@ -67,19 +68,7 @@ class MiscCog(commands.Cog):
 
             print(acceptanceMessage)
 
-            dbname = ""
-            card_author = ""
-            if (len(acceptanceMessage)) == 0 or "by " not in acceptanceMessage:
-                ...  # This is really the case of setting both to "", but due to scoping i got lazy
-            elif acceptanceMessage[0:3] == "by ":
-                card_author = str((acceptanceMessage.split("by "))[1])
-            else:
-                messageChunks = acceptanceMessage.split(" by ")
-                firstPart = messageChunks[0]
-                secondPart = "".join(messageChunks[1:])
-
-                dbname = str(firstPart)
-                card_author = str(secondPart)
+            dbname, card_author = parseCardNameAndAuthor(acceptanceMessage)
             resolvedName = dbname if dbname != "" else "Crazy card with no name"
             resolvedAuthor = card_author if card_author != "" else "no author"
             cardMessage = f"**{resolvedName}** by **{resolvedAuthor}**"

--- a/getCardMessage.py
+++ b/getCardMessage.py
@@ -6,9 +6,7 @@ def parseCardNameAndAuthor(acceptanceMessage: str) -> tuple[str, str]:
     elif acceptanceMessage[0:3] == "by ":
         card_author = str((acceptanceMessage.split("by "))[1])
     else:
-        messageChunks = acceptanceMessage.split(" by ")
-        firstPart = messageChunks[0]
-        secondPart = "".join(messageChunks[1:])
+        firstPart, secondPart = acceptanceMessage.rsplit(" by ", 1)
         dbname = str(firstPart)
         card_author = str(secondPart)
 

--- a/handleVetoPost.py
+++ b/handleVetoPost.py
@@ -55,7 +55,7 @@ async def handleVetoPost(
     copy_for_discussion = await message.attachments[0].to_file()
 
     mentions = [role.mention, judgeRole.mention]
-    splitted = message.content.split(" by ")
+    splitted = message.content.rsplit(" by ", 1)
     author_s = splitted[1] if splitted.__len__() > 1 else "NO AUTHOR"
     creator_mentions = author_s.split("; ")
 

--- a/submissions/tokenSubmissions.py
+++ b/submissions/tokenSubmissions.py
@@ -19,6 +19,7 @@ from discord import Message
 
 from discord.utils import get
 
+from getCardMessage import parseCardNameAndAuthor
 from is_mork import getDriveUrl, is_mork, uploadToDrive
 
 tokenUnapproved = googleClient.open_by_key(hc_constants.HELLSCUBE_DATABASE).worksheet(
@@ -79,8 +80,8 @@ async def acceptTokenSubmission(bot: commands.Bot, message: Message):
             f"<@{str(mentionEntry)}>", message.mentions[index].name
         )
 
-    cardName = accepted_message_no_mentions.split("\n")[0].split(" by ")[0]
-    creator = accepted_message_no_mentions.split("\n")[0].split(" by ")[1]
+    first_line = accepted_message_no_mentions.split("\n")[0]
+    cardName, creator = parseCardNameAndAuthor(first_line)
     relatedCards = accepted_message_no_mentions.split("\n")[1]
 
     await message.add_reaction(hc_constants.ACCEPT)


### PR DESCRIPTION
## Summary
- Parse `Cardname by Author` using the **last** `" by "` occurrence so card names can contain that substring (e.g. `Card by Something by Author` → name `Card by Something`, author `Author`).
- Centralize parsing in `parseCardNameAndAuthor` and route veto posts, token submissions, and duplicated Lifecycle/Misc handlers through it.

## Test plan
- [x] Verified `parseCardNameAndAuthor("Card by Something by Author")` returns `("Card by Something", "Author")`
- [ ] Accept a card whose name includes `" by "` and confirm the author is parsed correctly


Made with [Cursor](https://cursor.com)