### PR TITLE
Skip corrupt media during Reddit catchup

### DIFF
--- a/deferred_reddit.py
+++ b/deferred_reddit.py
@@ -47,6 +47,10 @@ def _is_reddit_media_too_large(exc: BaseException) -> bool:
     return "too large" in str(exc).lower()
 
 
+def _is_reddit_media_upload_failed(exc: BaseException) -> bool:
+    return "attempted media upload action has failed" in str(exc).lower()
+
+
 def _cleanup_deferred_batch(batch_dir: str) -> None:
     manifest_path = os.path.join(batch_dir, "manifest.txt")
     remaining_lines: list[str] = []
@@ -84,7 +88,7 @@ async def process_deferred_reddit_posts(count: int) -> tuple[int, list[str]]:
             posted += 1
             affected_batches.add(post.batch_dir)
         except Exception as e:
-            if _is_reddit_media_too_large(e):
+            if _is_reddit_media_too_large(e) or _is_reddit_media_upload_failed(e):
                 os.remove(post.image_path)
                 posted += 1
                 affected_batches.add(post.batch_dir)


### PR DESCRIPTION
## Summary
- When `!redditcatchup` hits Reddit's "attempted media upload action has failed" error (corrupt/unopenable media), treat it like a successful post
- Removes the bad image from the deferred batch and cleans up the manifest so the queue can keep moving

## Test plan
- [ ] Run `!redditcatchup` against a deferred post that previously failed with the corrupt-media upload error
- [ ] Confirm the post is removed from the pending list and catchup continues with remaining items
- [ ] Confirm normal Reddit upload failures still surface as errors


Made with [Cursor](https://cursor.com)