### PR TITLE
compileveto: place accepted cards into HC9.0

### DIFF
--- a/cogs/Lifecycle.py
+++ b/cogs/Lifecycle.py
@@ -1018,8 +1018,8 @@ class LifecycleCog(commands.Cog):
                 set_to_add_to = errata_card.cardset()
                 channel_to_add_to = card_list_channel_for_set(errata_card.cardset())
             else:
-                set_to_add_to = "SOH"
-                channel_to_add_to = hc_constants.SOH_CARD_LIST
+                set_to_add_to = "HC9.0"
+                channel_to_add_to = hc_constants.NINE_CARD_LIST
 
             await accept_card(
                 bot=self.bot,


### PR DESCRIPTION
## Summary
- After the SOH cutover, `!compileveto` was placing non-errata accepts into SOH
- Point the compileveto fallback set/channel back to `HC9.0` / `NINE_CARD_LIST`
- Errata accepts still follow the card’s existing set

## Test plan
- [ ] Run `!compileveto` on a non-errata accepted poll and confirm the card lands in the HC9 card-list channel with set `HC9.0`
- [ ] Confirm an errata accept still uses the errata card’s set/channel
- [ ] Confirm default `accept_card` / submissions paths still use SOH


Made with [Cursor](https://cursor.com)