### PR TITLE
compileveto: place accepted cards into SOH

### DIFF
--- a/cogs/Lifecycle.py
+++ b/cogs/Lifecycle.py
@@ -1018,8 +1018,8 @@ class LifecycleCog(commands.Cog):
                 set_to_add_to = errata_card.cardset()
                 channel_to_add_to = card_list_channel_for_set(errata_card.cardset())
             else:
-                set_to_add_to = "HC9.0"
-                channel_to_add_to = hc_constants.NINE_CARD_LIST
+                set_to_add_to = "SOH"
+                channel_to_add_to = hc_constants.SOH_CARD_LIST
 
             await accept_card(
                 bot=self.bot,


### PR DESCRIPTION
## Summary
- Switch `!compileveto` non-errata accepts back to set `SOH` / `SOH_CARD_LIST`
- Errata accepts still follow the card’s existing set

## Test plan
- [ ] Run `!compileveto` on a non-errata accepted poll and confirm the card lands in the SOH card-list channel with set `SOH`
- [ ] Confirm an errata accept still uses the errata card’s set/channel


Made with [Cursor](https://cursor.com)