### PR TITLE
Accept cards via GCS instead of Drive

### DIFF
--- a/acceptCard.py
+++ b/acceptCard.py
@@ -13,7 +13,7 @@ from hellfall_postcard import (
     rollback_postcard_write,
     sync_accepted_card,
 )
-from is_mork import getDriveUrl, uploadToDrive
+from gcs_card_images import upload_card_image
 from shared_vars import googleClient
 from discord.ext import commands
 
@@ -24,6 +24,17 @@ from username_mappings import resolve_authors
 cardSheetUnapproved = googleClient.open_by_key(
     hc_constants.HELLSCUBE_DATABASE
 ).worksheet(hc_constants.DATABASE_UNAPPROVED)
+
+
+def _upload_accepted_image(
+    image_path: str, *, object_name: str, existing_image_url: Optional[str]
+) -> str:
+    """Store the accepted image in hellscube-images (GCS), never Drive."""
+    return upload_card_image(
+        image_path,
+        object_name=object_name,
+        existing_url=existing_image_url,
+    )
 
 
 async def _sync_card_to_hellfall(
@@ -54,9 +65,10 @@ async def _resolve_accepted_image_url(
     author_name: str,
     set_id: str,
     hcid: Optional[str],
-    image_id_to_update: Optional[str],
+    existing_image_url: Optional[str],
     require_hellfall_postcard: bool,
 ) -> tuple[str, Optional[PostcardWrite]]:
+    object_name = hcid or card_name
     if require_hellfall_postcard:
         image_base64 = base64.b64encode(file_data).decode("ascii")
         postcard_write: Optional[PostcardWrite] = None
@@ -79,15 +91,14 @@ async def _resolve_accepted_image_url(
             postcard_write = None
 
         if not image_url:
-            google_drive_file_id = uploadToDrive(
+            gcs_url = _upload_accepted_image(
                 image_path,
-                image_id_to_update,
-                folder_id=hc_constants.CURRENT_SET_FOLDER,
+                object_name=object_name,
+                existing_image_url=existing_image_url,
             )
-            drive_url = getDriveUrl(google_drive_file_id)
             postcard_write = await sync_accepted_card(
                 name=card_name,
-                image=drive_url,
+                image=gcs_url,
                 creators=author_name,
                 set_id=set_id,
                 hcid=hcid,
@@ -97,7 +108,7 @@ async def _resolve_accepted_image_url(
             image_url = (
                 postcard_write.image_url
                 if postcard_write and postcard_write.image_url
-                else drive_url
+                else gcs_url
             )
 
         if not postcard_write:
@@ -106,10 +117,11 @@ async def _resolve_accepted_image_url(
             raise PostcardSyncError("hellfall did not return imageUrl")
         return image_url, postcard_write
 
-    google_drive_file_id = uploadToDrive(
-        image_path, image_id_to_update, folder_id=hc_constants.CURRENT_SET_FOLDER
+    image_url = _upload_accepted_image(
+        image_path,
+        object_name=object_name,
+        existing_image_url=existing_image_url,
     )
-    image_url = getDriveUrl(google_drive_file_id)
     postcard_write = await _sync_card_to_hellfall(
         card_name=card_name,
         image_url=image_url,
@@ -156,14 +168,13 @@ async def accept_card(
     index = [i for i in range(len(allCards)) if str(allCards[i][0]) == str(errataId)]
 
     newCard = True
-    image_id_to_update = None
+    existing_image_url: Optional[str] = None
     # At least on match was found, and the name isn't blank. There really shouldn't be any nameless cards though cause it breaks
     if cardName != "" and index.__len__() > 0:
         dbRowIndex = index[0] + 1
         newCard = False
-        image_id_to_update = allCards[index[0]][2].removeprefix(
-            "https://lh3.googleusercontent.com/d/"
-        )
+        if len(allCards[index[0]]) > 2 and allCards[index[0]][2]:
+            existing_image_url = str(allCards[index[0]][2])
     else:
         dbRowIndex = len(allCards) + 1
         if cardName == "":
@@ -183,7 +194,7 @@ async def accept_card(
             author_name=authorName,
             set_id=setId,
             hcid=firestore_hcid,
-            image_id_to_update=image_id_to_update,
+            existing_image_url=existing_image_url,
             require_hellfall_postcard=require_hellfall_postcard,
         )
 
@@ -272,26 +283,27 @@ async def accept_veto_card(
     ]
 
     newCard = True
-    image_id_to_update = None
+    existing_image_url: Optional[str] = None
     # At least on match was found, and the name isn't blank
     if cardName != "" and index.__len__() > 0:
         dbRowIndex = index[0] + 1
         newCard = False
-        image_id_to_update = allCards[index[0]][1].removeprefix(
-            "https://lh3.googleusercontent.com/d/"
-        )
+        if len(allCards[index[0]]) > 2 and allCards[index[0]][2]:
+            existing_image_url = str(allCards[index[0]][2])
     else:
         dbRowIndex = len(allCards) + 1
         if cardName == "":
             cardName = "NO NAME"
 
-    google_drive_file_id = uploadToDrive(image_path, image_id_to_update)
-
-    imageUrl = getDriveUrl(google_drive_file_id)
-
     existing_hcid = None
     if not newCard and len(allCards[index[0]]) > 0 and allCards[index[0]][0]:
         existing_hcid = str(allCards[index[0]][0])
+
+    imageUrl = _upload_accepted_image(
+        image_path,
+        object_name=existing_hcid or cardName,
+        existing_image_url=existing_image_url,
+    )
 
     postcard_write = None
     try:

--- a/cogs/lifecycle/design_hell_acceptance.py
+++ b/cogs/lifecycle/design_hell_acceptance.py
@@ -47,7 +47,7 @@ async def accept_design_hell_card(
     setId: str,
     channelIdForCard: int,
 ) -> None:
-    """Accept a Design Hell card via Drive/sheet/Discord and POST /api/cards/postcard."""
+    """Accept a Design Hell card via GCS/sheet/Discord and POST /api/cards/postcard."""
     await accept_card(
         bot=bot,
         file=file,

--- a/gcs_card_images.py
+++ b/gcs_card_images.py
@@ -1,0 +1,98 @@
+"""Upload accepted card/token images to Google Cloud Storage (hellscube-images).
+
+Matches Hellfall postcard object naming so Database column C URLs stay compatible
+with ``IMAGE_GCS_CARD_IMAGE_BUCKET``.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from typing import Optional
+from urllib.parse import quote, unquote, urlparse
+
+from google.cloud import storage
+
+DEFAULT_BUCKET = os.environ.get("GCS_CARD_IMAGE_BUCKET", "hellscube-images")
+DEFAULT_CREDENTIALS = os.environ.get(
+    "GOOGLE_APPLICATION_CREDENTIALS", "./bot_secrets/client_secrets.json"
+)
+_GCS_HOSTS = frozenset({"storage.googleapis.com", "storage.cloud.google.com"})
+
+
+def slug_object_name(name: str) -> str:
+    base = name.strip() or "image"
+    return re.sub(r"[^\w\-.]+", "_", base.replace("/", "|"), flags=re.UNICODE)[:180]
+
+
+def public_gcs_url(bucket_name: str, object_key: str) -> str:
+    encoded = "/".join(quote(segment, safe="") for segment in object_key.split("/"))
+    return f"https://storage.googleapis.com/{bucket_name}/{encoded}"
+
+
+def parse_gcs_public_url(
+    url: str, expected_bucket: Optional[str] = None
+) -> Optional[tuple[str, str]]:
+    try:
+        parsed = urlparse(url.strip())
+    except Exception:
+        return None
+    if parsed.hostname not in _GCS_HOSTS:
+        return None
+    path_parts = [p for p in parsed.path.lstrip("/").split("/") if p]
+    if len(path_parts) < 2:
+        return None
+    bucket = path_parts[0]
+    object_key = unquote("/".join(path_parts[1:]))
+    if not object_key:
+        return None
+    if expected_bucket and bucket != expected_bucket:
+        return None
+    return bucket, object_key
+
+
+def _content_type_for_ext(ext: str) -> str:
+    return {
+        ".png": "image/png",
+        ".jpg": "image/jpeg",
+        ".jpeg": "image/jpeg",
+        ".webp": "image/webp",
+        ".gif": "image/gif",
+    }.get(ext.lower(), "application/octet-stream")
+
+
+def upload_card_image(
+    path: str,
+    *,
+    object_name: str,
+    existing_url: Optional[str] = None,
+    bucket_name: Optional[str] = None,
+    credentials_path: Optional[str] = None,
+) -> str:
+    """Upload a local image to the card-image bucket; return its public HTTPS URL.
+
+    If ``existing_url`` points at the same bucket, overwrite that object (errata).
+    Otherwise create ``{slug(object_name)}{ext}``.
+    """
+    bucket_name = bucket_name or DEFAULT_BUCKET
+    credentials_path = credentials_path or DEFAULT_CREDENTIALS
+    ext = os.path.splitext(path)[1].lower() or ".png"
+    if ext == ".jpeg":
+        ext = ".jpg"
+
+    parsed = (
+        parse_gcs_public_url(existing_url, expected_bucket=bucket_name)
+        if existing_url
+        else None
+    )
+    if parsed:
+        object_key = parsed[1]
+    else:
+        object_key = f"{slug_object_name(object_name)}{ext}"
+
+    client = storage.Client.from_service_account_json(credentials_path)
+    blob = client.bucket(bucket_name).blob(object_key)
+    blob.upload_from_filename(path, content_type=_content_type_for_ext(ext))
+    blob.cache_control = "public, max-age=31536000"
+    blob.patch()
+    return public_gcs_url(bucket_name, object_key)

--- a/scripts/test_gcs_card_images.py
+++ b/scripts/test_gcs_card_images.py
@@ -1,0 +1,42 @@
+import unittest
+
+from gcs_card_images import (
+    parse_gcs_public_url,
+    public_gcs_url,
+    slug_object_name,
+)
+
+
+class GcsCardImagesTests(unittest.TestCase):
+    def test_slug_matches_hellfall_style(self):
+        self.assertEqual(slug_object_name("3682"), "3682")
+        # Hellfall replaces "/" with "|" then non-[\\w\\-.] with "_", so "|" becomes "_"
+        self.assertEqual(slug_object_name("Foo/Bar"), "Foo_Bar")
+        self.assertEqual(slug_object_name("a b!c"), "a_b_c")
+
+    def test_public_url_encodes_segments(self):
+        self.assertEqual(
+            public_gcs_url("hellscube-images", "3682.png"),
+            "https://storage.googleapis.com/hellscube-images/3682.png",
+        )
+        self.assertEqual(
+            public_gcs_url("hellscube-images", "Foo|Bar.png"),
+            "https://storage.googleapis.com/hellscube-images/Foo%7CBar.png",
+        )
+
+    def test_parse_gcs_url(self):
+        parsed = parse_gcs_public_url(
+            "https://storage.googleapis.com/hellscube-images/3682.png",
+            expected_bucket="hellscube-images",
+        )
+        self.assertEqual(parsed, ("hellscube-images", "3682.png"))
+        self.assertIsNone(
+            parse_gcs_public_url(
+                "https://lh3.googleusercontent.com/d/abc",
+                expected_bucket="hellscube-images",
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/submissions/tokenSubmissions.py
+++ b/submissions/tokenSubmissions.py
@@ -21,8 +21,7 @@ from discord import Message
 from discord.utils import get
 
 from getCardMessage import parseCardNameAndAuthor
-from gcs_card_images import upload_card_image
-from is_mork import is_mork
+from is_mork import getDriveUrl, is_mork, uploadToDrive
 from hellfall_postcard import (
     PostcardSyncError,
     rollback_postcard_write,
@@ -147,23 +146,20 @@ async def acceptTokenSubmission(bot: commands.Bot, message: Message):
             with open(image_path, "wb") as out:
                 out.write(file_data)
             try:
-                gcs_image_url = upload_card_image(
-                    image_path, object_name=final_card_name
+                google_drive_file_id = uploadToDrive(
+                    image_path, folder_id=hc_constants.TOKEN_FOLDER
                 )
+                drive_image_url = getDriveUrl(google_drive_file_id)
                 postcard_write = await sync_accepted_card(
                     name=final_card_name,
-                    image=gcs_image_url,
+                    image=drive_image_url,
                     creators=creator,
                     set_id="HCT",
                     hcid=final_card_name,
                     kind="token",
                     require_sync=True,
                 )
-                imageUrl = (
-                    postcard_write.image_url
-                    if postcard_write and postcard_write.image_url
-                    else gcs_image_url
-                )
+                imageUrl = drive_image_url
             finally:
                 if os.path.exists(image_path):
                     os.remove(image_path)

--- a/submissions/tokenSubmissions.py
+++ b/submissions/tokenSubmissions.py
@@ -21,7 +21,8 @@ from discord import Message
 from discord.utils import get
 
 from getCardMessage import parseCardNameAndAuthor
-from is_mork import getDriveUrl, is_mork, uploadToDrive
+from gcs_card_images import upload_card_image
+from is_mork import is_mork
 from hellfall_postcard import (
     PostcardSyncError,
     rollback_postcard_write,
@@ -146,20 +147,23 @@ async def acceptTokenSubmission(bot: commands.Bot, message: Message):
             with open(image_path, "wb") as out:
                 out.write(file_data)
             try:
-                google_drive_file_id = uploadToDrive(
-                    image_path, folder_id=hc_constants.TOKEN_FOLDER
+                gcs_image_url = upload_card_image(
+                    image_path, object_name=final_card_name
                 )
-                drive_image_url = getDriveUrl(google_drive_file_id)
                 postcard_write = await sync_accepted_card(
                     name=final_card_name,
-                    image=drive_image_url,
+                    image=gcs_image_url,
                     creators=creator,
                     set_id="HCT",
                     hcid=final_card_name,
                     kind="token",
                     require_sync=True,
                 )
-                imageUrl = drive_image_url
+                imageUrl = (
+                    postcard_write.image_url
+                    if postcard_write and postcard_write.image_url
+                    else gcs_image_url
+                )
             finally:
                 if os.path.exists(image_path):
                     os.remove(image_path)


### PR DESCRIPTION
## Summary
- Replace Google Drive uploads in Accept / veto Accept / token fallback with uploads to `hellscube-images` (same bucket Hellfall postcard uses).
- Design Hell still prefers postcard `imageBase64` (Hellfall → GCS); on `invalid_body` it falls back to Mork GCS instead of Drive.
- Errata overwrites an existing GCS object when column C already has a `hellscube-images` URL.

## Test plan
- [ ] Unit: `PYTHONPATH=. python -m unittest scripts.test_gcs_card_images`
- [ ] Accept a card in a test env; confirm Database col C is `https://storage.googleapis.com/hellscube-images/...` and Discord card list still posts
- [ ] Confirm Accept no longer fails when Drive is unavailable
- [ ] Token accept with postcard `invalid_body` fallback writes a GCS URL
- [ ] Errata on an existing GCS URL overwrites the same object


Made with [Cursor](https://cursor.com)