### PR TITLE
Write Hellfall postcard id to Database column BA

### DIFF
--- a/acceptCard.py
+++ b/acceptCard.py
@@ -25,6 +25,9 @@ cardSheetUnapproved = googleClient.open_by_key(
     hc_constants.HELLSCUBE_DATABASE
 ).worksheet(hc_constants.DATABASE_UNAPPROVED)
 
+# Column BA — Hellfall/Firestore card doc id returned by postcard sync
+_HELLFALL_ID_COL = 53
+
 
 def _upload_accepted_image(
     image_path: str, *, object_name: str, existing_image_url: Optional[str]
@@ -201,14 +204,21 @@ async def accept_card(
         cardSheetUnapproved.update_cell(dbRowIndex, 3, imageUrl)
 
         if newCard:
-            cardSheetUnapproved.update_cells(
-                [
-                    Cell(row=dbRowIndex, col=1, value=str(next_id)),
-                    Cell(row=dbRowIndex, col=2, value=cardName),
-                    Cell(row=dbRowIndex, col=4, value=authorName),
-                    Cell(row=dbRowIndex, col=5, value=setId),
-                ]
-            )
+            new_card_cells = [
+                Cell(row=dbRowIndex, col=1, value=str(next_id)),
+                Cell(row=dbRowIndex, col=2, value=cardName),
+                Cell(row=dbRowIndex, col=4, value=authorName),
+                Cell(row=dbRowIndex, col=5, value=setId),
+            ]
+            if postcard_write is not None and postcard_write.doc_id:
+                new_card_cells.append(
+                    Cell(
+                        row=dbRowIndex,
+                        col=_HELLFALL_ID_COL,
+                        value=postcard_write.doc_id,
+                    )
+                )
+            cardSheetUnapproved.update_cells(new_card_cells)
     except Exception:
         if postcard_write is not None:
             await rollback_postcard_write(postcard_write)
@@ -323,12 +333,19 @@ async def accept_veto_card(
         )
 
         if newCard:
-            cardSheetUnapproved.update_cells(
-                [
-                    Cell(row=dbRowIndex, col=2, value=cardName),
-                    Cell(row=dbRowIndex, col=4, value=authorName),
-                ]
-            )
+            new_card_cells = [
+                Cell(row=dbRowIndex, col=2, value=cardName),
+                Cell(row=dbRowIndex, col=4, value=authorName),
+            ]
+            if postcard_write is not None and postcard_write.doc_id:
+                new_card_cells.append(
+                    Cell(
+                        row=dbRowIndex,
+                        col=_HELLFALL_ID_COL,
+                        value=postcard_write.doc_id,
+                    )
+                )
+            cardSheetUnapproved.update_cells(new_card_cells)
     except Exception:
         if postcard_write is not None:
             await rollback_postcard_write(postcard_write)

--- a/acceptCard.py
+++ b/acceptCard.py
@@ -25,7 +25,7 @@ cardSheetUnapproved = googleClient.open_by_key(
     hc_constants.HELLSCUBE_DATABASE
 ).worksheet(hc_constants.DATABASE_UNAPPROVED)
 
-# Column BA — Hellfall/Firestore card doc id returned by postcard sync
+# Column BA (header UUID) — Hellfall card ``id`` from postcard response
 _HELLFALL_ID_COL = 53
 
 
@@ -210,12 +210,12 @@ async def accept_card(
                 Cell(row=dbRowIndex, col=4, value=authorName),
                 Cell(row=dbRowIndex, col=5, value=setId),
             ]
-            if postcard_write is not None and postcard_write.doc_id:
+            if postcard_write is not None and postcard_write.hellfall_id:
                 new_card_cells.append(
                     Cell(
                         row=dbRowIndex,
                         col=_HELLFALL_ID_COL,
-                        value=postcard_write.doc_id,
+                        value=postcard_write.hellfall_id,
                     )
                 )
             cardSheetUnapproved.update_cells(new_card_cells)
@@ -337,12 +337,12 @@ async def accept_veto_card(
                 Cell(row=dbRowIndex, col=2, value=cardName),
                 Cell(row=dbRowIndex, col=4, value=authorName),
             ]
-            if postcard_write is not None and postcard_write.doc_id:
+            if postcard_write is not None and postcard_write.hellfall_id:
                 new_card_cells.append(
                     Cell(
                         row=dbRowIndex,
                         col=_HELLFALL_ID_COL,
-                        value=postcard_write.doc_id,
+                        value=postcard_write.hellfall_id,
                     )
                 )
             cardSheetUnapproved.update_cells(new_card_cells)

--- a/hellfall_postcard.py
+++ b/hellfall_postcard.py
@@ -19,6 +19,9 @@ class PostcardWrite:
     was_create: bool
     previous: dict[str, Any] | None
     image_url: str | None = None
+    # Hellfall card UUID from response ``id`` (sheet BA / token L). Not always
+    # equal to ``doc_id`` on updates — use this for sheet UUID columns.
+    hellfall_id: str | None = None
 
 
 def postcard_sync_enabled() -> bool:
@@ -98,11 +101,16 @@ async def sync_accepted_card(
 
             previous = data.get("previous")
             image_url = data.get("imageUrl")
+            # postcard.ts returns ``id`` (Hellfall UUID). Fall back to docId for
+            # older responses where create used the same value for both.
+            raw_id = data.get("id") or data.get("cardId") or data.get("docId")
+            hellfall_id = str(raw_id) if raw_id else None
             return PostcardWrite(
                 doc_id=str(data["docId"]),
                 was_create=bool(data["wasCreate"]),
                 previous=previous if isinstance(previous, dict) else None,
                 image_url=str(image_url) if image_url else None,
+                hellfall_id=hellfall_id,
             )
 
 

--- a/submissions/tokenSubmissions.py
+++ b/submissions/tokenSubmissions.py
@@ -32,6 +32,9 @@ tokenUnapproved = googleClient.open_by_key(hc_constants.HELLSCUBE_DATABASE).work
     hc_constants.TOKEN_UNAPPROVED
 )
 
+# Column L (header UUID) — Hellfall card ``id`` from postcard response
+_HELLFALL_ID_COL = 12
+
 
 async def checkTokenSubmissions(bot: commands.Bot):
     print("checking token submissions")
@@ -167,14 +170,21 @@ async def acceptTokenSubmission(bot: commands.Bot, message: Message):
         if not imageUrl:
             raise PostcardSyncError("hellfall did not return imageUrl")
 
-        tokenUnapproved.update_cells(
-            [
-                Cell(row=dbRowIndex, col=1, value=final_card_name),
-                Cell(row=dbRowIndex, col=2, value=imageUrl),
-                Cell(row=dbRowIndex, col=6, value=relatedCards),
-                Cell(row=dbRowIndex, col=8, value=creator),
-            ]
-        )
+        token_cells = [
+            Cell(row=dbRowIndex, col=1, value=final_card_name),
+            Cell(row=dbRowIndex, col=2, value=imageUrl),
+            Cell(row=dbRowIndex, col=6, value=relatedCards),
+            Cell(row=dbRowIndex, col=8, value=creator),
+        ]
+        if postcard_write is not None and postcard_write.hellfall_id:
+            token_cells.append(
+                Cell(
+                    row=dbRowIndex,
+                    col=_HELLFALL_ID_COL,
+                    value=postcard_write.hellfall_id,
+                )
+            )
+        tokenUnapproved.update_cells(token_cells)
         await tokenListChannel.send(
             content=cardName + " by " + creator + "\n" + relatedCards,
             file=copy,


### PR DESCRIPTION
## Summary
- When accepting a **new** card, if Hellfall postcard sync returns a `docId`, write it to column **BA** (53) on `Database (Unapproved)`.
- Same behavior for new veto-card accepts when a postcard write is present.
- Sheet col A remains the numeric HC id; BA stores the Hellfall/Firestore UUID (header `HCID`).

## Test plan
- [ ] Accept a new card with postcard sync enabled; confirm BA on the new unapproved row equals the Hellfall `docId`
- [ ] Accept an errata/update (existing row); confirm BA is left unchanged by this change
- [ ] With postcard sync disabled / no write, confirm new-card accept still fills A–E and does not error on BA


Made with [Cursor](https://cursor.com)