### PR TITLE
Fix errata submissions channel id

### DIFF
--- a/hc_constants.py
+++ b/hc_constants.py
@@ -74,7 +74,6 @@ VETO_HELLPITS = 1242640978360274994
 
 # Card discussion: user posts "Card ID\nSome text"; bot replaces with formatted post + thread.
 
-ERRATA_SUBMISSIONS = 1480409711277899898
 MODWORK_REQUEST_CHANNEL = 1460534723498737808
 
 # Users


### PR DESCRIPTION
## Summary
- `hc_constants.py` defined `ERRATA_SUBMISSIONS` twice; the second value (`148040…`, old HC8) overwrote the correct channel (`862023130716438549`).
- Remove the duplicate so errata submissions, veto-threshold scanning, and hellpit resubmits use `#errata-submissions`.

## Test plan
- [ ] Confirm `ERRATA_SUBMISSIONS` resolves to `862023130716438549` only once in `hc_constants.py`
- [ ] Post/react in errata submissions and confirm lifecycle uses that channel
- [ ] Hellpit ✅ resubmit still lands in `#errata-submissions`


Made with [Cursor](https://cursor.com)