### PR TITLE
Write collector numbers to Unapproved column W

### DIFF
--- a/CardClasses.py
+++ b/CardClasses.py
@@ -77,6 +77,7 @@ class CardSearch:
         tags: list[str],
         artists: list[str],
         id: str,
+        collector_number: str = "",
     ):
         self._id = id
         self._name = name
@@ -90,6 +91,7 @@ class CardSearch:
         self._rulings = rulings
         self._tags = tags
         self._artists = artists
+        self._collector_number = collector_number
 
     def name(self):
         return self._name
@@ -129,6 +131,9 @@ class CardSearch:
 
     def id(self):
         return self._id
+
+    def collector_number(self):
+        return self._collector_number
 
     def types(self):
         returnList: list[str] = []

--- a/acceptCard.py
+++ b/acceptCard.py
@@ -28,8 +28,26 @@ cardSheetUnapproved = googleClient.open_by_key(
 # Column BB (header UUID) — Hellfall card ``id`` from postcard response
 _HELLFALL_ID_COL = 54
 
-# Column BC (header UUID) — Hellfall card ``oracle_id`` from postcard response
+# Column BC (header Oracle ID) — Hellfall card ``oracle_id`` from postcard response
 _ORACLE_ID_COL = 55
+
+# Column W — collector number
+_COLLECTOR_NUMBER_COL = 23
+
+
+def _next_collector_number_for_set(set_id: str) -> str:
+    """Return the next collector number for ``set_id`` (max leading digits in W + 1)."""
+    sets = cardSheetUnapproved.col_values(5)[2:]  # col E from row 3
+    collectors = cardSheetUnapproved.col_values(_COLLECTOR_NUMBER_COL)[2:]  # col W
+    max_num = 0
+    for i, sheet_set in enumerate(sets):
+        if sheet_set != set_id:
+            continue
+        cn = collectors[i] if i < len(collectors) else ""
+        match = re.match(r"^(\d+)", str(cn))
+        if match:
+            max_num = max(max_num, int(match.group(1)))
+    return str(max_num + 1)
 
 
 def _upload_accepted_image(
@@ -212,6 +230,11 @@ async def accept_card(
                 Cell(row=dbRowIndex, col=2, value=cardName),
                 Cell(row=dbRowIndex, col=4, value=authorName),
                 Cell(row=dbRowIndex, col=5, value=setId),
+                Cell(
+                    row=dbRowIndex,
+                    col=_COLLECTOR_NUMBER_COL,
+                    value=_next_collector_number_for_set(setId),
+                ),
             ]
             if postcard_write is not None and postcard_write.hellfall_id:
                 new_card_cells.append(

--- a/cogs/HellscubeDatabase.py
+++ b/cogs/HellscubeDatabase.py
@@ -26,6 +26,15 @@ notMagicCardSheet = databaseSheets.worksheet("NotMagic")
 client = discord.Client(intents=intents)
 
 
+def _sheet_has_collector_number(headers: list[str]) -> bool:
+    """True when col W is collector # and Side 2 Cost starts at X."""
+    return (
+        len(headers) > 23
+        and headers[22] != "Cost"
+        and headers[23] == "Cost"
+    )
+
+
 def build_database():
     global cardList
     cardList = []
@@ -35,7 +44,11 @@ def build_database():
     set_username_mappings(usernameMappings)
 
     cardSheetSearch = databaseSheets.worksheet("Database")
-    cardsDataSearch = cardSheetSearch.get_all_values()[2:]
+    all_values = cardSheetSearch.get_all_values()
+    headers = all_values[1]
+    has_collector = _sheet_has_collector_number(headers)
+    side2_start = 23 if has_collector else 22
+    cardsDataSearch = all_values[2:]
 
     for entry in cardsDataSearch:
         creator_alias = next(
@@ -58,14 +71,16 @@ def build_database():
             colors = entry[9].split(";")
             artists = entry[20].split(";") if entry[20] != "" else []
             tags = entry[21].split(";") if entry[21] != "" else []
+            collector_number = (
+                entry[22] if has_collector and len(entry) > 22 else ""
+            )
             sides = []
             sides.append(create_side(entry[10:19]))  # Name to Image
-            if entry[24] != "" and entry[24] != " ":
-                sides.append(create_side(entry[22:31]))
-            if entry[34] != "" and entry[34] != " ":
-                sides.append(create_side(entry[32:41]))
-            if entry[44] != "" and entry[44] != " ":
-                sides.append(create_side(entry[42:51]))
+            for face_offset in (0, 10, 20):
+                start = side2_start + face_offset
+                type_idx = start + 2
+                if len(entry) > type_idx and entry[type_idx] != "" and entry[type_idx] != " ":
+                    sides.append(create_side(entry[start : start + 9]))
 
             cardList.append(
                 CardSearch(
@@ -81,6 +96,7 @@ def build_database():
                     rulings=rulings,
                     tags=tags,
                     artists=artists,
+                    collector_number=collector_number,
                 )
             )
         except Exception as e:
@@ -548,6 +564,8 @@ def format_card_info(card: CardSearch) -> str:
         f"set: {cardset}",
         f"legality: {legality}",
     ]
+    if card.collector_number():
+        to_send.append(f"collector #: {card.collector_number()}")
     if artists.__len__() > 0:
         to_send.append("artists: " + ", ".join(artists))
     if tags.__len__() > 0:

--- a/hellfall_postcard.py
+++ b/hellfall_postcard.py
@@ -19,10 +19,10 @@ class PostcardWrite:
     was_create: bool
     previous: dict[str, Any] | None
     image_url: str | None = None
-    # Hellfall card UUID from response ``id`` (sheet BA / token L). Not always
+    # Hellfall card UUID from response ``id`` (sheet BB / token L). Not always
     # equal to ``doc_id`` on updates — use this for sheet UUID columns.
     hellfall_id: str | None = None
-    # Oracle card UUID from response ``oracle_id`` (sheet BA / token M).
+    # Oracle card UUID from response ``oracle_id`` (sheet BC / token M).
     oracle_id: str | None = None
 
 

--- a/submissions/tokenSubmissions.py
+++ b/submissions/tokenSubmissions.py
@@ -34,8 +34,21 @@ tokenUnapproved = googleClient.open_by_key(hc_constants.HELLSCUBE_DATABASE).work
 
 # Column L (header UUID) — Hellfall card ``id`` from postcard response
 _HELLFALL_ID_COL = 12
-# Column M (header UUID) — Hellfall card ``oracle_id`` from postcard response
+# Column M (header Oracle ID) — Hellfall card ``oracle_id`` from postcard response
 _ORACLE_ID_COL = 13
+# Column J — collector number
+_COLLECTOR_NUMBER_COL = 10
+
+
+def _next_token_collector_number() -> str:
+    """Return the next token collector number (max leading digits in J + 1)."""
+    collectors = tokenUnapproved.col_values(_COLLECTOR_NUMBER_COL)
+    max_num = 0
+    for cn in collectors:
+        match = re.match(r"^(\d+)", str(cn))
+        if match:
+            max_num = max(max_num, int(match.group(1)))
+    return str(max_num + 1)
 
 
 async def checkTokenSubmissions(bot: commands.Bot):
@@ -177,6 +190,11 @@ async def acceptTokenSubmission(bot: commands.Bot, message: Message):
             Cell(row=dbRowIndex, col=2, value=imageUrl),
             Cell(row=dbRowIndex, col=6, value=relatedCards),
             Cell(row=dbRowIndex, col=8, value=creator),
+            Cell(
+                row=dbRowIndex,
+                col=_COLLECTOR_NUMBER_COL,
+                value=_next_token_collector_number(),
+            ),
         ]
         if postcard_write is not None and postcard_write.hellfall_id:
             token_cells.append(


### PR DESCRIPTION
## Summary
- Unapproved Database column W is collector number (header often still `AO`); accepts now assign the next number per set on new cards, and tokens write the next CN to column J.
- `HellscubeDatabase` / `!info` learn collector # when the sheet has the inserted column, while keeping Approved working (W still Side 2 Cost until that sheet gets the same insert).
- Comment fixes for UUID/Oracle columns (BB/BC) after the W insert.

## Test plan
- [ ] Accept a new SOH card and confirm Unapproved col W is max(SOH)+1 and BB/BC still receive Hellfall ids when postcard sync is on
- [ ] Accept a token and confirm Unapproved Tokens col J gets the next CN
- [ ] Restart bot / rebuild DB against Approved: multi-face cards still parse; no false collector # until Approved gains column W
- [ ] After Approved gains W: `!info` shows collector # and side faces still parse

Made with [Cursor](https://cursor.com)