### PR TITLE
Return nameless submissions instead of eating them

### DIFF
--- a/.cursor/rules/card-flows.mdc
+++ b/.cursor/rules/card-flows.mdc
@@ -1,0 +1,35 @@
+---
+description: Keep docs/card-flows in sync when card lifecycle behavior changes
+globs: cogs/Lifecycle.py,acceptCard.py,checkSubmissions.py,handleVetoPost.py,getCardMessage.py,submissions/**,cogs/lifecycle/**
+alwaysApply: false
+---
+
+# Card flow documentation
+
+When you change card lifecycle behavior, update the matching docs in the same change set.
+
+## When this applies
+
+Behavior changes in submission intake, polls, veto, acceptance, errata, tokens, design hell, or background submission checks.
+
+## What to update
+
+| Code area | Doc |
+|-----------|-----|
+| `#submissions`, `#pause-projects`, tokens, design hell | `docs/card-flows/submissions.md` |
+| Veto polls, `!compileveto`, hellpit | `docs/card-flows/veto.md` |
+| `accept_card`, postcard, persistence | `docs/card-flows/acceptance.md` |
+| Errata channel, instaerrata | `docs/card-flows/errata.md` |
+| Background loop, Reddit, lookups | `docs/card-flows/background.md` |
+| Cross-cutting lifecycle changes | `docs/card-flows/overview.md` |
+
+## Requirements
+
+- Update Mermaid diagrams and validation tables when branching, thresholds, channels, cooldowns, or user-visible outcomes change.
+- Keep `#submissions-discussion` pings, image return/delete behavior, and cooldown consumption accurate.
+- If behavior spans multiple areas, update every affected page—not just `submissions.md`.
+
+## PR checklist
+
+- [ ] Matching `docs/card-flows/*.md` updated (or N/A with reason in PR description)
+- [ ] Diagrams and tables reflect the new behavior

--- a/cogs/Lifecycle.py
+++ b/cogs/Lifecycle.py
@@ -35,7 +35,7 @@ from cogs.lifecycle.design_hell_acceptance import (
     get_current_design_hell_set_id,
 )
 from cogs.lifecycle.submissions_day_markers import ensure_submissions_day_marker
-from getCardMessage import getCardMessage, parseCardNameAndAuthor
+from getCardMessage import getCardMessage, parseCardNameAndAuthor, submission_card_name
 from getVetoPollsResults import (
     VetoPollResults,
     getVetoPollsResults,
@@ -651,6 +651,17 @@ class LifecycleCog(commands.Cog):
                         'No "@" are allowed in card title submissions to prevent me from spamming'
                     )
                     return  # no pings allowed
+
+                if not submission_card_name(message.content):
+                    discussionChannel = getSubmissionDiscussionChannel(self.bot)
+                    file = await message.attachments[0].to_file()
+                    await discussionChannel.send(
+                        f"<@{message.author.id}>, make sure to include the name of your card",
+                        file=file,
+                    )
+                    await message.delete()
+                    return
+
                 author = message.author.mention
 
                 print(f"{cardName} submitted by {message.author.mention}")
@@ -691,14 +702,6 @@ class LifecycleCog(commands.Cog):
                         f"{message.author.id}—{datetime.now(tz=timezone.utc).strftime('%Y-%m-%dT%H:%M:%S%z')}\n"
                     )
 
-                if message.content == "":
-                    discussionChannel = getSubmissionDiscussionChannel(self.bot)
-                    await discussionChannel.send(
-                        f"<@{message.author.id}>, make sure to include the name of your card"
-                    )
-                    await message.delete()
-                    return
-
                 file = await message.attachments[0].to_file()
                 if reasonable_card():
                     vetoChannel = getVetoChannel(bot=self.bot)
@@ -736,15 +739,17 @@ class LifecycleCog(commands.Cog):
 
             case hc_constants.MASTERPIECE_CHANNEL:
                 if len(message.attachments) > 0:
-                    if message.content == "":
+                    if not submission_card_name(message.content):
                         discussionChannel = cast(
                             TextChannel,
                             self.bot.get_channel(
                                 hc_constants.SUBMISSIONS_DISCUSSION_CHANNEL
                             ),
                         )
+                        file = await message.attachments[0].to_file()
                         await discussionChannel.send(
-                            f"<@{message.author.id}>, make sure to include the name of your card"
+                            f"<@{message.author.id}>, make sure to include the name of your card",
+                            file=file,
                         )
                         await message.delete()
                         return

--- a/docs/card-flows/README.md
+++ b/docs/card-flows/README.md
@@ -2,6 +2,8 @@
 
 Mermaid diagrams for card-related workflows in Mork. Mork is mostly stateless, instead relying on reddit, discord, hellfall, and reddit.
 
+**Maintaining these docs:** When you change card lifecycle behavior (intake, polls, veto, acceptance, errata, background checks), update the matching page under `docs/card-flows/` in the same PR. See `.cursor/rules/card-flows.mdc`.
+
 ## Flow index
 
 | Doc                                  | Contents                                                                     |

--- a/docs/card-flows/overview.md
+++ b/docs/card-flows/overview.md
@@ -8,7 +8,7 @@
 flowchart TD
   subgraph submit["1 · Community submission"]
     A["User posts to #submissions<br/>CardName by @author(;s) + image"] --> IN{"Intake OK? image · name · cooldown · no @ in title"}
-    IN -->|no| X["Ignore or ping<br/>#submissions-discussion"]
+    IN -->|no| X["Ignore, ping, or return image<br/>#submissions-discussion"]
     IN -->|yes| MAG{"Feeling lucky?"}
     MAG -->|no| POLL["Mork reposts poll<br/>👍 👎 ❌ + thread"]
     POLL --> LOOP["Background check · 5 min"]

--- a/docs/card-flows/submissions.md
+++ b/docs/card-flows/submissions.md
@@ -50,7 +50,7 @@ flowchart TD
   POST["User posts in #submissions"] --> A{"Any attachment?"}
 
   A -->|no| MI["Missing image<br/>No bot reply<br/>Post stays in channel<br/>Cooldown NOT consumed"]
-  A -->|yes| B{"First line empty?<br/>(no card name)"}
+  A -->|yes| B{"First line has card name?<br/>(non-empty after trim)"}
   B -->|yes| NN["Missing name<br/>Ping in #submissions-discussion<br/>Image returned · post deleted<br/>Cooldown NOT consumed"]
   B -->|no| OK["Normal submission flow"]
 
@@ -68,6 +68,8 @@ flowchart TD
 | **Non-image attachment** | e.g. PDF attached                 | Poll created anyway                          | Deleted (reposted as poll) | Consumed       |
 | **Magic skip**           | 1/4001 roll                       | Straight to veto (no poll)                   | Deleted                    | Consumed       |
 
+**Missing name:** Intake bails before cooldown write or repost. The card image is reattached in `#submissions-discussion` so the user can fix the title and resubmit. Whitespace-only first lines count as missing.
+
 **Missing image:** Intake bails before cooldown, name checks, or repost. Text-only posts stay in channel with no ping to attach an image.
 
 **Image detection elsewhere:** Day markers and the daily submissions gallery only count messages whose first attachment is an image (`image/*` content type or `.png` / `.jpg` / `.jpeg` / `.gif` / `.webp` / `.bmp`). That filter does not apply at initial `#submissions` intake.
@@ -76,14 +78,20 @@ flowchart TD
 
 ## Masterpiece / Pause Projects submission
 
-Same shape as standard submission; different channel, threshold, and cooldown state file.
+Same intake validation as standard submission (attachment, `@` in title, card name, cooldown); different channel, poll threshold, and cooldown state file.
 
 ```mermaid
 flowchart TD
   U["User posts to #pause-projects"] --> ATT{"Any attachment?"}
   ATT -->|no| MISS["Silent ignore<br/>(same as #submissions missing image)"]
-  ATT -->|yes| CD["Separate cooldown file"]
-  CD --> POLL["Mork poll 👍👎❌"]
+  ATT -->|yes| NAME{"First line has card name?"}
+  NAME -->|no| NONAME["#submissions-discussion:<br/>include card name + image returned<br/>Post deleted · cooldown NOT consumed"]
+  NAME -->|yes| PING{"@ in card title?"}
+  PING -->|yes| DM["DM user: no @ in title<br/>original post kept"]
+  PING -->|no| CD{"User on masterpiece cooldown?"}
+  CD -->|no| WAIT["#submissions-discussion:<br/>wait message + delete post"]
+  CD -->|yes| COOL["Write masterpiece cooldown timestamp"]
+  COOL --> POLL["Mork poll 👍👎❌"]
   POLL --> CHK{"up − down ≥ 45<br/>age ≥ 1 day?"}
   CHK -->|yes| VP["#veto-polls"]
   VP --> HVP["Veto poll setup"]

--- a/docs/card-flows/submissions.md
+++ b/docs/card-flows/submissions.md
@@ -14,12 +14,12 @@ flowchart TD
   ATT -->|no| MISS["Silent ignore — see validation"]
   ATT -->|yes| PING{"@ in card title?"}
   PING -->|yes| DM["DM user: no @ in title<br/>original post kept"]
-  PING -->|no| CD{"User is on the submission cooldown?"}
+  PING -->|no| NAME{"First line has card name?"}
+  NAME -->|no| NONAME["#submissions-discussion:<br/>include card name + image returned<br/>Post deleted · cooldown NOT consumed"]
+  NAME -->|yes| CD{"User is on the submission cooldown?"}
   CD -->|no| X["#submissions-discussion:<br/>wait N hours + delete post"]
   CD -->|yes| COOL["Write cooldown timestamp"]
-  COOL --> NAME{"content non-empty?"}
-  NAME -->|no| NONAME["#submissions-discussion:<br/>include card name + delete<br/>(cooldown consumed)"]
-  NAME -->|yes| DEL["Delete user post"]
+  COOL --> DEL["Delete user post"]
   DEL --> MAGIC{"Feeling lucky?"}
   MAGIC -->|yes| VP["#veto-polls + discussion + log<br/>(no community poll)"]
   MAGIC -->|no| POLL["Mork reposts with 👍👎❌ + thread"]
@@ -51,7 +51,7 @@ flowchart TD
 
   A -->|no| MI["Missing image<br/>No bot reply<br/>Post stays in channel<br/>Cooldown NOT consumed"]
   A -->|yes| B{"First line empty?<br/>(no card name)"}
-  B -->|yes| NN["Missing name<br/>Ping in #submissions-discussion<br/>Delete post<br/>Cooldown IS consumed"]
+  B -->|yes| NN["Missing name<br/>Ping in #submissions-discussion<br/>Image returned · post deleted<br/>Cooldown NOT consumed"]
   B -->|no| OK["Normal submission flow"]
 
   A -->|non-image file<br/>e.g. .pdf| NI["No image-type check on intake<br/>Poll still created"]
@@ -62,7 +62,7 @@ flowchart TD
 | Case                     | Trigger                           | Bot response                                 | User post                  | Cooldown       |
 | ------------------------ | --------------------------------- | -------------------------------------------- | -------------------------- | -------------- |
 | **Missing image**        | No attachment                     | None (silent ignore)                         | **Kept** in `#submissions` | Not written    |
-| **Missing card name**    | Attachment present, empty content | `#submissions-discussion`: include card name | Deleted                    | **Consumed**   |
+| **Missing card name**    | Attachment present, empty/whitespace first line | `#submissions-discussion`: include card name + image returned | Deleted                    | Not written    |
 | **`@` in title**         | `@` in first line                 | DM: no `@` allowed                           | Kept                       | Not written    |
 | **On cooldown**          | Submitted within 22 h             | `#submissions-discussion`: wait message      | Deleted                    | Already active |
 | **Non-image attachment** | e.g. PDF attached                 | Poll created anyway                          | Deleted (reposted as poll) | Consumed       |

--- a/docs/codebase-layout.md
+++ b/docs/codebase-layout.md
@@ -16,7 +16,7 @@ Because of that, the “application” modules stay next to `Mork.py`. **Do not 
 | `submissions/` | Async checks for token, masterpiece, and errata flows |
 | `scripts/` | One-off CLIs (sheets, Drive, GCS). Always run from repo root: `python scripts/<name>.py` |
 | `bot_secrets/` | Local credentials (gitignored); use `*.template.py` as a guide |
-| `docs/` | Deployment and layout notes (this file, GCP + Actions guide, [card flows](card-flows/README.md)) |
+| `docs/` | Deployment and layout notes (this file, GCP + Actions guide, [card flows](card-flows/README.md)). Update card-flow docs when lifecycle behavior changes. |
 | `.github/workflows/` | CI (pre-commit) and optional deploy workflows |
 
 ## Root modules (libraries used by cogs)

--- a/getCardMessage.py
+++ b/getCardMessage.py
@@ -1,3 +1,7 @@
+def submission_card_name(content: str) -> str:
+    return (content or "").strip().split("\n", 1)[0].strip()
+
+
 def parseCardNameAndAuthor(acceptanceMessage: str) -> tuple[str, str]:
     dbname = ""
     card_author = ""

--- a/scripts/test_submission_card_name.py
+++ b/scripts/test_submission_card_name.py
@@ -1,0 +1,21 @@
+import unittest
+
+from getCardMessage import submission_card_name
+
+
+class SubmissionCardNameTests(unittest.TestCase):
+    def test_empty_content(self):
+        self.assertEqual(submission_card_name(""), "")
+
+    def test_whitespace_only(self):
+        self.assertEqual(submission_card_name("   \n"), "")
+
+    def test_uses_first_line_only(self):
+        self.assertEqual(submission_card_name("Bolt\nby @user"), "Bolt")
+
+    def test_strips_surrounding_whitespace(self):
+        self.assertEqual(submission_card_name("  Lightning Bolt  "), "Lightning Bolt")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Validate card name (including whitespace-only titles) before writing submission cooldown in `#submissions`
- On missing name, reattach the submission image in `#submissions-discussion` so users get their card back
- Apply the same image-return behavior to `#pause-projects` / masterpiece intake
- Update submission flow docs and add unit tests for `submission_card_name`

## Test plan
- [x] `python -m unittest scripts.test_submission_card_name -v`
- [ ] Post to `#submissions` with image but no card name → ping in discussion includes image, cooldown not consumed
- [ ] Post with whitespace-only first line → same rejection path
- [ ] Post with valid name → normal poll flow unchanged


Made with [Cursor](https://cursor.com)