### PR TITLE
Send imageMimeType on Hellfall postcard uploads

### DIFF
--- a/acceptCard.py
+++ b/acceptCard.py
@@ -19,6 +19,10 @@ from discord.ext import commands
 
 
 from deferred_reddit import format_deferred_manifest_entry, safe_card_filename
+from image_response_filename import (
+    extension_from_image_bytes,
+    mime_type_from_image_bytes,
+)
 from reddit_devvit import post_accept_via_devvit, reddit_accept_via_devvit_enabled
 from reddit_functions import post_to_reddit, reddit_title_for_acceptance
 from username_mappings import resolve_authors
@@ -71,6 +75,7 @@ async def _resolve_accepted_image_url(
     postcard_write = await sync_accepted_card(
         name=card_name,
         image_base64=image_base64,
+        image_mime_type=mime_type_from_image_bytes(file_data),
         creators=author_name,
         set_id=set_id,
         hcid=hcid,
@@ -104,12 +109,16 @@ async def accept_card(
     """Accept a cards a card into the DB. This also includes posting it to reddit and the appropriate card list channel."""
     authorName = resolve_authors(authorName)
     ext_match = re.search(r"(\.[^.]+)$", file.filename or "")
-    file_type = ext_match.group(1) if ext_match else ".png"
-    new_file_name = safe_card_filename(cardName, file_type)
     os.makedirs("tempImages", exist_ok=True)
-    image_path = f"tempImages/{uuid.uuid4().hex}{file_type}"
 
     file_data = file.fp.read()
+    file_type = extension_from_image_bytes(file_data) or (
+        ext_match.group(1) if ext_match else ".png"
+    )
+    if file_type.lower() == ".jpeg":
+        file_type = ".jpg"
+    new_file_name = safe_card_filename(cardName, file_type)
+    image_path = f"tempImages/{uuid.uuid4().hex}{file_type}"
     file_copy_for_cardlist = discord.File(
         fp=io.BytesIO(file_data), filename=new_file_name
     )

--- a/docs/card-flows/acceptance.md
+++ b/docs/card-flows/acceptance.md
@@ -87,6 +87,8 @@ flowchart TD
 
 Mork does **not** upload card or token images to GCS or Drive. Hellfall receives `imageBase64` via the postcard API, uploads to `hellscube-images` server-side, and returns `imageUrl`.
 
+Discord card-list attachments and deferred Reddit files use the extension from **magic bytes** (GIF/PNG/JPEG/WebP), not a hardcoded `.png`. Postcard also sends `imageMimeType` (from those bytes) with `imageBase64` so Hellfall can store GIFs as `.gif`.
+
 ### Hellfall postcard sync
 
 Optional for most accepts; **mandatory** for Design Hell (`require_hellfall_postcard=True`).
@@ -99,7 +101,7 @@ Optional for most accepts; **mandatory** for Design Hell (`require_hellfall_post
 
 **Endpoint:** `POST {HELLFALL_API_URL}/api/cards/postcard`
 
-Payload includes `name`, `creators`, `set`, `kind: "card"`, and `imageBase64`. Errata and new cards both send `hcid` (existing id or next numeric id).
+Payload includes `name`, `creators`, `set`, `kind: "card"`, `imageBase64`, and `imageMimeType` (`image/png`, `image/gif`, `image/jpeg`, or `image/webp` when sniffable). Errata and new cards both send `hcid` (existing id or next numeric id).
 
 **Response used:** `imageUrl`, `id` (Hellfall UUID → sheet col BB), `oracle_id` (→ col BC). On new cards only, UUID columns are written when sync succeeds.
 

--- a/hellfall_postcard.py
+++ b/hellfall_postcard.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import base64
 import json
 import os
 from dataclasses import dataclass
 from typing import Any, Literal, Optional
 
 import aiohttp
+
+from image_response_filename import mime_type_from_image_bytes
 
 
 class PostcardSyncError(Exception):
@@ -63,11 +66,53 @@ def _postcard_request_context(
     hcid: Optional[str],
     image: Optional[str],
     image_base64: Optional[str],
+    image_mime_type: Optional[str],
 ) -> str:
     return (
         f"kind={kind} name={name!r} set={set_id!r} hcid={hcid!r} "
-        f"has_image_url={bool(image)} has_image_base64={bool(image_base64)}"
+        f"has_image_url={bool(image)} has_image_base64={bool(image_base64)} "
+        f"image_mime_type={image_mime_type!r}"
     )
+
+
+def _sniff_mime_from_base64(image_base64: str) -> str | None:
+    try:
+        prefix = image_base64[:32]
+        pad = "=" * ((4 - len(prefix) % 4) % 4)
+        raw = base64.b64decode(prefix + pad, validate=False)
+    except Exception:
+        return None
+    return mime_type_from_image_bytes(raw)
+
+
+def build_postcard_payload(
+    *,
+    name: str,
+    creators: str,
+    set_id: str,
+    kind: str,
+    image: Optional[str] = None,
+    image_base64: Optional[str] = None,
+    image_mime_type: Optional[str] = None,
+    hcid: Optional[str] = None,
+) -> dict[str, str]:
+    """JSON body for POST /api/cards/postcard."""
+    payload: dict[str, str] = {
+        "name": name,
+        "creators": creators,
+        "set": set_id,
+        "kind": kind,
+    }
+    if image_base64:
+        payload["imageBase64"] = image_base64
+        mime = (image_mime_type or "").strip() or _sniff_mime_from_base64(image_base64)
+        if mime:
+            payload["imageMimeType"] = mime
+    elif image:
+        payload["image"] = image
+    if hcid:
+        payload["hcid"] = hcid
+    return payload
 
 
 def _payload_summary(payload: dict[str, str]) -> str:
@@ -105,6 +150,7 @@ async def sync_accepted_card(
     set_id: str,
     image: Optional[str] = None,
     image_base64: Optional[str] = None,
+    image_mime_type: Optional[str] = None,
     hcid: Optional[str] = None,
     kind: Literal["card", "token"] = "card",
     require_sync: bool = False,
@@ -122,18 +168,16 @@ async def sync_accepted_card(
     if not image and not image_base64:
         raise PostcardSyncError("image or image_base64 is required")
 
-    payload: dict[str, str] = {
-        "name": name,
-        "creators": creators,
-        "set": set_id,
-        "kind": kind,
-    }
-    if image_base64:
-        payload["imageBase64"] = image_base64
-    elif image:
-        payload["image"] = image
-    if hcid:
-        payload["hcid"] = hcid
+    payload = build_postcard_payload(
+        name=name,
+        creators=creators,
+        set_id=set_id,
+        kind=kind,
+        image=image,
+        image_base64=image_base64,
+        image_mime_type=image_mime_type,
+        hcid=hcid,
+    )
 
     request_context = _postcard_request_context(
         kind=kind,
@@ -142,6 +186,7 @@ async def sync_accepted_card(
         hcid=hcid,
         image=image,
         image_base64=image_base64,
+        image_mime_type=payload.get("imageMimeType"),
     )
     _postcard_debug(
         f"POST /api/cards/postcard payload={_payload_summary(payload)} {request_context}"

--- a/image_response_filename.py
+++ b/image_response_filename.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import re
 from urllib.parse import unquote, urlparse
 
@@ -11,33 +12,83 @@ _CONTENT_DISPOSITION_FILENAME_RE = re.compile(
 )
 _IMAGE_EXTENSIONS = frozenset({".png", ".jpg", ".jpeg", ".webp", ".gif"})
 
+_PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+_JPEG_MAGIC = b"\xff\xd8\xff"
+_CONTENT_TYPE_FOR_EXT = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".webp": "image/webp",
+    ".gif": "image/gif",
+}
 
-def _extension_from_content_type(content_type: str | None) -> str:
-    ctype = (content_type or "").split(";")[0].strip().lower()
-    if "png" in ctype:
+
+def extension_from_image_bytes(body: bytes | None) -> str | None:
+    """Return a lowercase image extension from magic bytes, or None if unknown."""
+    if not body:
+        return None
+    if body.startswith(b"GIF8"):
+        return ".gif"
+    if body.startswith(_PNG_MAGIC):
         return ".png"
+    if body.startswith(_JPEG_MAGIC):
+        return ".jpg"
+    if len(body) >= 12 and body.startswith(b"RIFF") and body[8:12] == b"WEBP":
+        return ".webp"
+    return None
+
+
+def content_type_for_ext(ext: str | None) -> str | None:
+    if not ext:
+        return None
+    if not ext.startswith("."):
+        ext = f".{ext}"
+    return _CONTENT_TYPE_FOR_EXT.get(ext.lower())
+
+
+def mime_type_from_image_bytes(body: bytes | None) -> str | None:
+    return content_type_for_ext(extension_from_image_bytes(body))
+
+
+def extension_from_content_type(content_type: str | None) -> str | None:
+    ctype = (content_type or "").split(";")[0].strip().lower()
+    if not ctype:
+        return None
+    if "gif" in ctype:
+        return ".gif"
     if "jpeg" in ctype or "jpg" in ctype:
         return ".jpg"
     if "webp" in ctype:
         return ".webp"
-    if "gif" in ctype:
-        return ".gif"
-    return ".png"
+    if "png" in ctype:
+        return ".png"
+    return None
 
 
-def filename_from_image_response(
+def with_image_extension(filename: str, ext: str) -> str:
+    """Set ``ext`` on ``filename``, replacing a known image suffix instead of appending."""
+    if not ext.startswith("."):
+        ext = f".{ext}"
+    ext = ".jpg" if ext.lower() == ".jpeg" else ext.lower()
+    root, old_ext = os.path.splitext(filename)
+    if old_ext.lower() in _IMAGE_EXTENSIONS:
+        return f"{root}{ext}"
+    return f"{filename}{ext}"
+
+
+def _candidate_filename(
     *,
     content_disposition: str | None,
     url: str,
-    content_type: str | None = None,
-    fallback_name: str = "image",
+    fallback_name: str,
 ) -> str:
-    """Drive ``inline;filename=`` first, then other CD forms, URL path, then fallback."""
     cd = content_disposition or ""
 
     drive_match = _DRIVE_FILENAME_RE.findall(cd)
     if drive_match:
-        return drive_match[0].strip()
+        name = drive_match[0].strip()
+        if name:
+            return name
 
     cd_match = _CONTENT_DISPOSITION_FILENAME_RE.search(cd)
     if cd_match:
@@ -52,8 +103,36 @@ def filename_from_image_response(
         if ext in _IMAGE_EXTENSIONS:
             return basename
 
-    ext = _extension_from_content_type(content_type)
     base = (fallback_name or "image").strip() or "image"
-    if any(base.lower().endswith(image_ext) for image_ext in _IMAGE_EXTENSIONS):
-        return base
-    return f"{base}{ext}"
+    return base
+
+
+def filename_from_image_response(
+    *,
+    content_disposition: str | None,
+    url: str,
+    content_type: str | None = None,
+    fallback_name: str = "image",
+    body: bytes | None = None,
+) -> str:
+    """Drive ``inline;filename=`` first, then other CD forms, URL path, then fallback.
+
+    Magic bytes and ``Content-Type`` win over a URL/Drive ``.png`` name when the
+    bytes are actually a GIF (or another format).
+    """
+    candidate = _candidate_filename(
+        content_disposition=content_disposition,
+        url=url,
+        fallback_name=fallback_name,
+    )
+    _, candidate_ext = os.path.splitext(candidate)
+    candidate_ext = (
+        candidate_ext.lower() if candidate_ext.lower() in _IMAGE_EXTENSIONS else ""
+    )
+    ext = (
+        extension_from_image_bytes(body)
+        or extension_from_content_type(content_type)
+        or candidate_ext
+        or ".png"
+    )
+    return with_image_extension(candidate, ext)

--- a/scripts/test_hellfall_postcard.py
+++ b/scripts/test_hellfall_postcard.py
@@ -1,0 +1,61 @@
+import base64
+import unittest
+
+from hellfall_postcard import build_postcard_payload
+
+GIF = b"GIF89a" + b"\x00" * 24
+PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 24
+
+
+class PostcardPayloadTests(unittest.TestCase):
+    def test_gif_bytes_send_image_gif_mime(self):
+        payload = build_postcard_payload(
+            name="Cool Card",
+            creators="Author",
+            set_id="SOH",
+            kind="card",
+            image_base64=base64.b64encode(GIF).decode("ascii"),
+            hcid="123",
+        )
+        self.assertEqual(payload["imageMimeType"], "image/gif")
+        self.assertIn("imageBase64", payload)
+        self.assertEqual(payload["hcid"], "123")
+
+    def test_explicit_mime_wins_over_sniff(self):
+        payload = build_postcard_payload(
+            name="Cool Card",
+            creators="Author",
+            set_id="SOH",
+            kind="card",
+            image_base64=base64.b64encode(PNG).decode("ascii"),
+            image_mime_type="image/gif",
+        )
+        self.assertEqual(payload["imageMimeType"], "image/gif")
+
+    def test_png_sniff(self):
+        payload = build_postcard_payload(
+            name="Cool Card",
+            creators="Author",
+            set_id="HCT",
+            kind="token",
+            image_base64=base64.b64encode(PNG).decode("ascii"),
+        )
+        self.assertEqual(payload["imageMimeType"], "image/png")
+
+    def test_image_url_path_omits_mime(self):
+        payload = build_postcard_payload(
+            name="Cool Card",
+            creators="Author",
+            set_id="SOH",
+            kind="card",
+            image="https://storage.googleapis.com/bucket/card.png",
+        )
+        self.assertNotIn("imageMimeType", payload)
+        self.assertEqual(
+            payload["image"],
+            "https://storage.googleapis.com/bucket/card.png",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_image_response_filename.py
+++ b/scripts/test_image_response_filename.py
@@ -1,0 +1,88 @@
+import unittest
+
+from image_response_filename import (
+    content_type_for_ext,
+    extension_from_image_bytes,
+    filename_from_image_response,
+    mime_type_from_image_bytes,
+    with_image_extension,
+)
+
+GIF = b"GIF89a" + b"\x00" * 24
+PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 24
+
+
+class ImageResponseFilenameTests(unittest.TestCase):
+    def test_sniff_gif_over_png_url(self):
+        name = filename_from_image_response(
+            content_disposition=None,
+            url="https://storage.googleapis.com/hellscube-images/CoolCard.png",
+            content_type="image/png",
+            fallback_name="CoolCard",
+            body=GIF,
+        )
+        self.assertEqual(name, "CoolCard.gif")
+
+    def test_content_type_gif_over_png_url(self):
+        name = filename_from_image_response(
+            content_disposition=None,
+            url="https://storage.googleapis.com/hellscube-images/CoolCard.png",
+            content_type="image/gif",
+            fallback_name="CoolCard",
+        )
+        self.assertEqual(name, "CoolCard.gif")
+
+    def test_drive_png_name_with_gif_bytes(self):
+        name = filename_from_image_response(
+            content_disposition='inline;filename="Foo.png"',
+            url="https://drive.google.com/uc?id=abc",
+            content_type="image/png",
+            body=GIF,
+        )
+        self.assertEqual(name, "Foo.gif")
+
+    def test_png_bytes_keep_png(self):
+        name = filename_from_image_response(
+            content_disposition=None,
+            url="https://storage.googleapis.com/hellscube-images/CoolCard.png",
+            content_type="image/png",
+            fallback_name="CoolCard",
+            body=PNG,
+        )
+        self.assertEqual(name, "CoolCard.png")
+
+    def test_fallback_without_type_defaults_png(self):
+        name = filename_from_image_response(
+            content_disposition=None,
+            url="https://example.com/noext",
+            fallback_name="Card",
+        )
+        self.assertEqual(name, "Card.png")
+
+    def test_fallback_gif_name_is_not_given_png(self):
+        name = filename_from_image_response(
+            content_disposition=None,
+            url="https://example.com/noext",
+            fallback_name="Card.gif",
+        )
+        self.assertEqual(name, "Card.gif")
+
+    def test_with_image_extension_replaces_instead_of_appending(self):
+        self.assertEqual(with_image_extension("Foo.gif", ".png"), "Foo.png")
+        self.assertEqual(with_image_extension("Foo.gif", ".gif"), "Foo.gif")
+        self.assertEqual(with_image_extension("Foo", ".gif"), "Foo.gif")
+
+    def test_extension_from_image_bytes(self):
+        self.assertEqual(extension_from_image_bytes(GIF), ".gif")
+        self.assertEqual(extension_from_image_bytes(PNG), ".png")
+        self.assertIsNone(extension_from_image_bytes(b"not-an-image"))
+
+    def test_mime_type_from_image_bytes(self):
+        self.assertEqual(mime_type_from_image_bytes(GIF), "image/gif")
+        self.assertEqual(mime_type_from_image_bytes(PNG), "image/png")
+        self.assertEqual(content_type_for_ext(".gif"), "image/gif")
+        self.assertIsNone(mime_type_from_image_bytes(b"not-an-image"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/submissions/tokenSubmissions.py
+++ b/submissions/tokenSubmissions.py
@@ -26,6 +26,7 @@ from hellfall_postcard import (
     rollback_postcard_write,
     sync_accepted_card,
 )
+from image_response_filename import content_type_for_ext, extension_from_image_bytes
 
 tokenUnapproved = googleClient.open_by_key(hc_constants.HELLSCUBE_DATABASE).worksheet(
     hc_constants.TOKEN_UNAPPROVED
@@ -111,12 +112,14 @@ async def acceptTokenSubmission(bot: commands.Bot, message: Message):
     copy = await message.attachments[0].to_file()
 
     extension = re.search(r"\.([^.]*)$", file.filename)
-    fileType = (
-        extension.group() if extension else ".png"
-    )  # just guess that the file is a png
-    new_file_name = f'{cardName.replace("/", "|")}{fileType}'
-
     file_data = file.fp.read()
+    fileType = extension_from_image_bytes(file_data) or (
+        extension.group() if extension else ".png"
+    )
+    if fileType.lower() == ".jpeg":
+        fileType = ".jpg"
+    new_file_name = f'{cardName.replace("/", "|")}{fileType}'
+    copy.filename = new_file_name
     image_base64 = base64.b64encode(file_data).decode("ascii")
 
     allCardNames = tokenUnapproved.col_values(1)
@@ -142,6 +145,7 @@ async def acceptTokenSubmission(bot: commands.Bot, message: Message):
         postcard_write = await sync_accepted_card(
             name=final_card_name,
             image_base64=image_base64,
+            image_mime_type=content_type_for_ext(fileType),
             creators=creator,
             set_id="HCT",
             hcid=final_card_name,


### PR DESCRIPTION
## Summary
- Postcard `POST /api/cards/postcard` now includes `imageMimeType` (`image/gif`, `image/png`, `image/jpeg`, `image/webp`) with `imageBase64`, sniffed from magic bytes when callers do not pass a type.
- Accept and token flows pass the sniffed mime so Hellfall can name GCS objects `.gif` instead of always `.png`.
- Hellfall needs to read `imageMimeType` when writing the object; extra JSON fields are ignored today, so this is safe to land before that change.

## Test plan
- [ ] `python -m unittest scripts.test_hellfall_postcard scripts.test_image_response_filename`
- [ ] Accept a GIF card and confirm the postcard debug log includes `imageMimeType='image/gif'`
- [ ] After Hellfall consumes the field, confirm the returned `imageUrl` ends in `.gif` and Discord `{{card}}` animates


Made with [Cursor](https://cursor.com)