### PR TITLE
Close #submissions on Tuesday and Saturday Eastern

### DIFF
--- a/cogs/General.py
+++ b/cogs/General.py
@@ -9,6 +9,7 @@ import hc_constants
 from discord.utils import get
 import random
 from datetime import date, datetime, timezone, timedelta
+from cogs.lifecycle.submissions_closed import elapsed_open_hours
 import aiohttp
 import io
 import re
@@ -643,9 +644,14 @@ class GeneralCog(commands.Cog):
                             "%Y-%m-%dT%H:%M:%S%z",
                         )
 
-                        timeSinceLast = (
-                            (datetime.now(tz=timezone.utc) - tempDate).total_seconds()
-                        ) / (60 * 60)
+                        if state_file == hc_constants.SUBMISSIONS_STATE_FILE:
+                            timeSinceLast = elapsed_open_hours(tempDate)
+                        else:
+                            timeSinceLast = (
+                                (
+                                    datetime.now(tz=timezone.utc) - tempDate
+                                ).total_seconds()
+                            ) / (60 * 60)
 
                         # Check if user is admin
                         member = cast(discord.Member, ctx.author)

--- a/cogs/Lifecycle.py
+++ b/cogs/Lifecycle.py
@@ -34,6 +34,10 @@ from cogs.lifecycle.design_hell_acceptance import (
     card_name_and_author_from_design_hell_message,
     get_current_design_hell_set_id,
 )
+from cogs.lifecycle.submissions_closed import (
+    elapsed_open_hours,
+    is_submissions_closed,
+)
 from cogs.lifecycle.submissions_day_markers import ensure_submissions_day_marker
 from getCardMessage import getCardMessage, parseCardNameAndAuthor, submission_card_name
 from getVetoPollsResults import (
@@ -668,6 +672,13 @@ class LifecycleCog(commands.Cog):
                 await message.delete()
 
             case hc_constants.SUBMISSIONS_CHANNEL:
+                if is_submissions_closed():
+                    discussionChannel = getSubmissionDiscussionChannel(self.bot)
+                    await discussionChannel.send(
+                        f"<@{message.author.id}>, It is closed"
+                    )
+                    await message.delete()
+                    return
                 if len(message.attachments) == 0:
                     return
 
@@ -709,11 +720,7 @@ class LifecycleCog(commands.Cog):
                                 "%Y-%m-%dT%H:%M:%S%z",
                             )
 
-                            timeSinceLast = (
-                                (
-                                    datetime.now(tz=timezone.utc) - tempDate
-                                ).total_seconds()
-                            ) / (60 * 60)
+                            timeSinceLast = elapsed_open_hours(tempDate)
 
                             if timeSinceLast < hc_constants.SUBMISSION_COOLDOWN and not is_admin(
                                 cast(discord.Member, message.author)
@@ -1392,9 +1399,10 @@ async def setup(bot: commands.Bot):
     await bot.add_cog(LifecycleCog(bot))
 
 
-def _reset_countdowns_for_file(state_file: str):
+def _reset_countdowns_for_file(state_file: str, *, pause_on_closed_days: bool = False):
     if not os.path.exists(state_file):
         return
+    now = datetime.now(tz=timezone.utc)
     lines_to_write = ""
     with open(state_file, "r") as file:
         lines = file.readlines()
@@ -1406,9 +1414,10 @@ def _reset_countdowns_for_file(state_file: str):
                     "%Y-%m-%dT%H:%M:%S%z",
                 )
 
-                timeSinceLast = (
-                    (datetime.now(tz=timezone.utc) - tempDate).total_seconds()
-                ) / (60 * 60)
+                if pause_on_closed_days:
+                    timeSinceLast = elapsed_open_hours(tempDate, now)
+                else:
+                    timeSinceLast = (now - tempDate).total_seconds() / (60 * 60)
 
                 if timeSinceLast <= hc_constants.SUBMISSION_COOLDOWN:
                     lines_to_write += f"{line}"
@@ -1418,7 +1427,9 @@ def _reset_countdowns_for_file(state_file: str):
 
 def reset_countdowns():
     print("reset")
-    _reset_countdowns_for_file(hc_constants.SUBMISSIONS_STATE_FILE)
+    _reset_countdowns_for_file(
+        hc_constants.SUBMISSIONS_STATE_FILE, pause_on_closed_days=True
+    )
     _reset_countdowns_for_file(hc_constants.MASTERPIECE_STATE_FILE)
     print("end reset")
 

--- a/cogs/lifecycle/submissions_closed.py
+++ b/cogs/lifecycle/submissions_closed.py
@@ -1,0 +1,45 @@
+"""US Eastern closed days for #submissions (Tuesday and Saturday)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
+
+SUBMISSIONS_TZ = ZoneInfo("America/New_York")
+CLOSED_WEEKDAYS = {1, 5}  # Tuesday, Saturday
+
+
+def _as_aware_utc(dt: datetime) -> datetime:
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def is_submissions_closed(at: datetime | None = None) -> bool:
+    """True for the full local calendar day Tuesday or Saturday in US Eastern."""
+    now = _as_aware_utc(at or datetime.now(timezone.utc))
+    return now.astimezone(SUBMISSIONS_TZ).weekday() in CLOSED_WEEKDAYS
+
+
+def elapsed_open_hours(start: datetime, end: datetime | None = None) -> float:
+    """Hours between start and end that are not Tuesday or Saturday US Eastern."""
+    start_utc = _as_aware_utc(start)
+    end_utc = _as_aware_utc(end or datetime.now(timezone.utc))
+    if end_utc <= start_utc:
+        return 0.0
+
+    open_seconds = 0.0
+    cursor = start_utc
+    while cursor < end_utc:
+        local = cursor.astimezone(SUBMISSIONS_TZ)
+        next_midnight_local = local.replace(
+            hour=0, minute=0, second=0, microsecond=0
+        ) + timedelta(days=1)
+        segment_end = min(end_utc, next_midnight_local.astimezone(timezone.utc))
+        if segment_end <= cursor:
+            cursor = cursor + timedelta(minutes=1)
+            continue
+        if local.weekday() not in CLOSED_WEEKDAYS:
+            open_seconds += (segment_end - cursor).total_seconds()
+        cursor = segment_end
+    return open_seconds / 3600

--- a/docs/card-flows/background.md
+++ b/docs/card-flows/background.md
@@ -8,7 +8,7 @@ Runs every 5 minutes. No idea which timezone the instance runs on.
 
 ```mermaid
 flowchart TD
-  LOOP["Every 5 minutes"] --> R1["Reset submission cooldowns"]
+  LOOP["Every 5 minutes"] --> R1["Reset submission cooldowns<br/>(#submissions skips Tue/Sat Eastern)"]
   R1 --> R2["Ensure submissions day marker"]
   R2 --> R3["Check standard submissions"]
   R3 --> R4["Check masterpiece submissions"]
@@ -23,6 +23,8 @@ flowchart TD
   LOOP --> T2{"Is it the <=4th minute of the 10th hour?"}
   T2 -->|yes| COTD["HC6 card-of-the-day → Reddit"]
 ```
+
+`reset_countdowns` keeps `#submissions` cooldown rows until 22 **open** hours have passed (Tuesday and Saturday in US Eastern do not count). Masterpiece cooldowns still use wall-clock hours.
 
 ---
 

--- a/docs/card-flows/overview.md
+++ b/docs/card-flows/overview.md
@@ -7,8 +7,8 @@
 ```mermaid
 flowchart TD
   subgraph submit["1 · Community submission"]
-    A["User posts to #submissions<br/>CardName by @author(;s) + image"] --> IN{"Intake OK? image · name · cooldown · no @ in title"}
-    IN -->|no| X["Ignore, ping, or return image<br/>#submissions-discussion"]
+    A["User posts to #submissions<br/>CardName by @author(;s) + image"] --> IN{"Intake OK? not Tue/Sat Eastern · image · name · cooldown · no @ in title"}
+    IN -->|no| X["Ignore, ping, closed, or return image<br/>#submissions-discussion"]
     IN -->|yes| MAG{"Feeling lucky?"}
     MAG -->|no| POLL["Mork reposts poll<br/>👍 👎 ❌ + thread"]
     POLL --> LOOP["Background check · 5 min"]

--- a/docs/card-flows/submissions.md
+++ b/docs/card-flows/submissions.md
@@ -6,11 +6,15 @@
 
 **Entry:** `#submissions` · background check every 5 min · `!wait` for cooldown
 
+Closed all day **Tuesday and Saturday** in US Eastern (`America/New_York`, EST/EDT). Those days do not count toward the 22h cooldown. `#pause-projects` and other intake channels stay open.
+
 ### Happy path
 
 ```mermaid
 flowchart TD
-  U["User: CardName by @author(s) + image attachment"] --> ATT{"Any attachment?"}
+  U["User: CardName by @author(s) + image attachment"] --> CLOSED{"Tue or Sat<br/>US Eastern?"}
+  CLOSED -->|yes| CLOSED_MSG["#submissions-discussion:<br/>It is closed<br/>Post deleted · cooldown NOT consumed<br/>wait clock paused"]
+  CLOSED -->|no| ATT{"Any attachment?"}
   ATT -->|no| MISS["Silent ignore — see validation"]
   ATT -->|yes| PING{"@ in card title?"}
   PING -->|yes| DM["DM user: no @ in title<br/>original post kept"]
@@ -47,7 +51,9 @@ flowchart TD
 
 ```mermaid
 flowchart TD
-  POST["User posts in #submissions"] --> A{"Any attachment?"}
+  POST["User posts in #submissions"] --> CLOSED{"Tue or Sat<br/>US Eastern?"}
+  CLOSED -->|yes| CL["#submissions-discussion: It is closed<br/>Post deleted · cooldown NOT consumed"]
+  CLOSED -->|no| A{"Any attachment?"}
 
   A -->|no| MI["Missing image<br/>No bot reply<br/>Post stays in channel<br/>Cooldown NOT consumed"]
   A -->|yes| B{"First line has card name?<br/>(non-empty after trim)"}
@@ -61,16 +67,19 @@ flowchart TD
 
 | Case                     | Trigger                           | Bot response                                 | User post                  | Cooldown       |
 | ------------------------ | --------------------------------- | -------------------------------------------- | -------------------------- | -------------- |
+| **Closed day**           | Tuesday or Saturday, US Eastern   | `#submissions-discussion`: `It is closed`    | Deleted                    | Not written; clock paused |
 | **Missing image**        | No attachment                     | None (silent ignore)                         | **Kept** in `#submissions` | Not written    |
 | **Missing card name**    | Attachment present, empty/whitespace first line | `#submissions-discussion`: include card name + image returned | Deleted                    | Not written    |
 | **`@` in title**         | `@` in first line                 | DM: no `@` allowed                           | Kept                       | Not written    |
-| **On cooldown**          | Submitted within 22 h             | `#submissions-discussion`: wait message      | Deleted                    | Already active |
+| **On cooldown**          | Submitted within 22 open hours (Tue/Sat Eastern excluded) | `#submissions-discussion`: wait message      | Deleted                    | Already active |
 | **Non-image attachment** | e.g. PDF attached                 | Poll created anyway                          | Deleted (reposted as poll) | Consumed       |
 | **Magic skip**           | 1/4001 roll                       | Straight to veto (no poll)                   | Deleted                    | Consumed       |
 
+**Closed day:** Checked first. Any user post in `#submissions` on Tuesday or Saturday (US Eastern) is deleted and pinged in `#submissions-discussion` with `It is closed`. Cooldown timestamps are not written, and elapsed wait time ignores those days.
+
 **Missing name:** Intake bails before cooldown write or repost. The card image is reattached in `#submissions-discussion` so the user can fix the title and resubmit. Whitespace-only first lines count as missing.
 
-**Missing image:** Intake bails before cooldown, name checks, or repost. Text-only posts stay in channel with no ping to attach an image.
+**Missing image:** Intake bails before cooldown, name checks, or repost. Text-only posts stay in channel with no ping to attach an image. Open days only; closed days delete the post and ping instead.
 
 **Image detection elsewhere:** Day markers and the daily submissions gallery only count messages whose first attachment is an image (`image/*` content type or `.png` / `.jpg` / `.jpeg` / `.gif` / `.webp` / `.bmp`). That filter does not apply at initial `#submissions` intake.
 
@@ -78,7 +87,7 @@ flowchart TD
 
 ## Masterpiece / Pause Projects submission
 
-Same intake validation as standard submission (attachment, `@` in title, card name, cooldown); different channel, poll threshold, and cooldown state file.
+Same intake validation as standard submission (attachment, `@` in title, card name, cooldown); different channel, poll threshold, and cooldown state file. Tuesday/Saturday closures apply only to `#submissions`.
 
 ```mermaid
 flowchart TD

--- a/scripts/test_submissions_closed.py
+++ b/scripts/test_submissions_closed.py
@@ -1,0 +1,67 @@
+"""Smoke tests for #submissions closed days (no Discord)."""
+
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from cogs.lifecycle.submissions_closed import (  # noqa: E402
+    elapsed_open_hours,
+    is_submissions_closed,
+)
+
+NY = ZoneInfo("America/New_York")
+
+
+def test_closed_weekdays():
+    assert is_submissions_closed(datetime(2026, 8, 18, 15, 0, tzinfo=NY))  # Tuesday
+    assert is_submissions_closed(datetime(2026, 8, 15, 0, 0, tzinfo=NY))  # Saturday
+    assert is_submissions_closed(datetime(2026, 8, 15, 23, 59, tzinfo=NY))
+    assert not is_submissions_closed(datetime(2026, 8, 17, 15, 0, tzinfo=NY))  # Monday
+    assert not is_submissions_closed(datetime(2026, 8, 19, 15, 0, tzinfo=NY))  # Wednesday
+    assert not is_submissions_closed(datetime(2026, 8, 16, 12, 0, tzinfo=NY))  # Sunday
+
+
+def test_closed_uses_eastern_not_utc():
+    # 03:00 UTC Tue = 23:00 EDT Mon. 04:30 UTC Tue = 00:30 EDT Tue.
+    assert not is_submissions_closed(datetime(2026, 8, 18, 3, 0, tzinfo=timezone.utc))
+    assert is_submissions_closed(datetime(2026, 8, 18, 4, 30, tzinfo=timezone.utc))
+
+
+def test_elapsed_skips_saturday():
+    start = datetime(2026, 8, 14, 23, 0, tzinfo=NY)  # Friday
+    end = datetime(2026, 8, 16, 1, 0, tzinfo=NY)  # Sunday
+    assert elapsed_open_hours(start, end) == 2.0
+
+
+def test_elapsed_skips_tuesday_for_cooldown():
+    start = datetime(2026, 8, 17, 10, 0, tzinfo=NY)  # Monday
+    still_waiting = datetime(2026, 8, 18, 8, 0, tzinfo=NY)  # Tuesday
+    assert elapsed_open_hours(start, still_waiting) == 14.0
+    done = datetime(2026, 8, 19, 8, 0, tzinfo=NY)  # Wednesday
+    assert elapsed_open_hours(start, done) == 22.0
+
+
+def test_elapsed_open_weekday_is_wall_clock():
+    start = datetime(2026, 8, 17, 10, 0, tzinfo=NY)
+    end = datetime(2026, 8, 17, 12, 0, tzinfo=NY)
+    assert elapsed_open_hours(start, end) == 2.0
+
+
+def test_elapsed_zero_when_end_before_start():
+    start = datetime(2026, 8, 17, 12, 0, tzinfo=NY)
+    end = datetime(2026, 8, 17, 10, 0, tzinfo=NY)
+    assert elapsed_open_hours(start, end) == 0.0
+
+
+if __name__ == "__main__":
+    test_closed_weekdays()
+    test_closed_uses_eastern_not_utc()
+    test_elapsed_skips_saturday()
+    test_elapsed_skips_tuesday_for_cooldown()
+    test_elapsed_open_weekday_is_wall_clock()
+    test_elapsed_zero_when_end_before_start()
+    print("ok")


### PR DESCRIPTION
## Summary
- `#submissions` is closed all day Tuesday and Saturday in US Eastern (`America/New_York`). Posts are deleted and `#submissions-discussion` is pinged with `It is closed`.
- The 22h cooldown ignores those closed days (intake, `!wait`, and submissions-file reset). `#pause-projects` and other intake channels are unchanged.

## Test plan
- [ ] `python scripts/test_submissions_closed.py`
- [ ] On a Tuesday or Saturday Eastern, post in `#submissions` and confirm the discussion ping plus delete
- [ ] Confirm a cooldown started Monday does not expire during Tuesday
- [ ] Confirm `#pause-projects` still accepts submissions on those days


Made with [Cursor](https://cursor.com)