### PR TITLE
Link the accepted card's submissions thread from the veto discussion thread

### DIFF
--- a/checkSubmissions.py
+++ b/checkSubmissions.py
@@ -167,6 +167,7 @@ async def checkSubmissions(bot: commands.Bot):
                     ),
                 )
 
+                # Submissions thread is not deleted with the message.
                 submission_thread = guild.get_channel_or_thread(messageEntry.id)
 
                 await asyncio.sleep(1)

--- a/checkSubmissions.py
+++ b/checkSubmissions.py
@@ -167,8 +167,17 @@ async def checkSubmissions(bot: commands.Bot):
                     ),
                 )
 
+                submission_thread = guild.get_channel_or_thread(messageEntry.id)
+
                 await asyncio.sleep(1)
-                await handleVetoPost(message=vetoEntry, bot=bot, veto_council=None)
+                await handleVetoPost(
+                    message=vetoEntry,
+                    bot=bot,
+                    veto_council=None,
+                    submission_thread_url=(
+                        submission_thread.jump_url if submission_thread else None
+                    ),
+                )
 
                 logContent = f"{acceptContent}, datetime: {f'<t:{int(messageEntry.created_at.timestamp())}:f>'}, message id: {messageEntry.id}, upvotes: {upCount}, downvotes: {downCount}"
                 await asyncio.sleep(1)

--- a/handleVetoPost.py
+++ b/handleVetoPost.py
@@ -14,6 +14,7 @@ async def handleVetoPost(
     message: Message,
     bot: commands.Bot,
     veto_council: int | None,
+    submission_thread_url: str | None = None,
 ):
     if portal_time:
         veto_council = hc_constants.VETO_COUNCIL_PORTAL
@@ -78,6 +79,9 @@ async def handleVetoPost(
     await veto_poll_thread.send(hellpit_discussion_thread.jump_url)
 
     await hellpit_discussion_thread.send(message.jump_url)
+
+    if submission_thread_url:
+        await hellpit_discussion_thread.send(submission_thread_url)
 
     await veto_poll_thread.edit(locked=True)
     return

--- a/submissions/checkMasterpieceSubmissions.py
+++ b/submissions/checkMasterpieceSubmissions.py
@@ -85,7 +85,19 @@ async def checkMasterpieceSubmissions(bot: commands.Bot):
                     content="SOH: " + accepted_message_no_mentions, file=copy
                 )
 
-                await handleVetoPost(vetoEntry, bot, None)
+                # Submissions thread is not deleted with the message.
+                submission_thread = messageEntry.guild.get_channel_or_thread(
+                    messageEntry.id
+                )
+
+                await handleVetoPost(
+                    vetoEntry,
+                    bot,
+                    None,
+                    submission_thread_url=(
+                        submission_thread.jump_url if submission_thread else None
+                    ),
+                )
 
                 copy2 = await messageEntry.attachments[0].to_file()
                 logContent = f"{acceptContent}, message id: {messageEntry.id}, upvotes: {upCount}, downvotes: {downCount}"


### PR DESCRIPTION
Mork posts a link to the accepted card's submissions thread after the link to the card's veto-polls message. Gives the submitter and VC easy access to review the public discussion. Applies to both the submissions and masterpiece.

It looks like this on my test server:
<img width="435" height="135" alt="image" src="https://github.com/user-attachments/assets/2febdbdd-ca37-47a5-ab06-80a7b68b23ae" />
