### PR TITLE
Add submissions gate announcements and testing closed-day behavior

### DIFF
--- a/cogs/Lifecycle.py
+++ b/cogs/Lifecycle.py
@@ -39,6 +39,7 @@ from cogs.lifecycle.submissions_closed import (
     is_submissions_closed,
 )
 from cogs.lifecycle.submissions_day_markers import ensure_submissions_day_marker
+from cogs.lifecycle.submissions_gates import ensure_submissions_gates
 from getCardMessage import getCardMessage, parseCardNameAndAuthor, submission_card_name
 from getVetoPollsResults import (
     VetoPollResults,
@@ -61,7 +62,7 @@ from is_admin import can_instaerrata, is_admin, is_veto
 from is_mork import is_mork, reasonable_card
 from image_response_filename import filename_from_image_response
 from post_card_images import post_card_images
-from reddit_devvit import reddit_cotd_via_devvit_enabled
+from reddit_devvit import reddit_cotd_via_devvit_enabled, reddit_mirror_via_devvit_enabled
 from reddit_functions import post_to_reddit
 from shared_vars import intents, googleClient
 
@@ -256,6 +257,10 @@ class LifecycleCog(commands.Cog):
         except Exception as e:
             print(e)
         try:
+            await ensure_submissions_gates(self.bot)
+        except Exception as e:
+            print(e)
+        try:
             await checkSubmissions(self.bot)
         except Exception:
             traceback.print_exc()
@@ -268,7 +273,8 @@ class LifecycleCog(commands.Cog):
         except Exception:
             traceback.print_exc()
         try:
-            await check_reddit(self.bot)
+            if not reddit_mirror_via_devvit_enabled():
+                await check_reddit(self.bot)
         except Exception:
             traceback.print_exc()
         try:
@@ -689,11 +695,19 @@ class LifecycleCog(commands.Cog):
 
             case hc_constants.SUBMISSIONS_CHANNEL:
                 if is_submissions_closed():
-                    discussionChannel = getSubmissionDiscussionChannel(self.bot)
-                    await discussionChannel.send(
-                        f"<@{message.author.id}>, It is closed"
-                    )
+                    author_id = message.author.id
+                    preview = (message.content or "").strip()
+                    attachment_count = len(message.attachments)
                     await message.delete()
+                    admin = await self.bot.fetch_user(hc_constants.LLLLLL)
+                    parts = [
+                        f"<@{author_id}> tried to post in #submissions while it was closed."
+                    ]
+                    if preview:
+                        parts.append(preview[:500])
+                    if attachment_count:
+                        parts.append(f"({attachment_count} attachment(s))")
+                    await admin.send("\n".join(parts))
                     return
                 if len(message.attachments) == 0:
                     return

--- a/cogs/lifecycle/submissions_closed.py
+++ b/cogs/lifecycle/submissions_closed.py
@@ -1,4 +1,4 @@
-"""US Eastern closed days for #submissions (Tuesday and Saturday)."""
+"""US Eastern closed days for #submissions (Tuesday, Thursday, and Saturday)."""
 
 from __future__ import annotations
 
@@ -6,7 +6,8 @@ from datetime import datetime, timedelta, timezone
 from zoneinfo import ZoneInfo
 
 SUBMISSIONS_TZ = ZoneInfo("America/New_York")
-CLOSED_WEEKDAYS = {1, 5}  # Tuesday, Saturday
+# Thursday included temporarily for testing.
+CLOSED_WEEKDAYS = {1, 3, 5}  # Tuesday, Thursday, Saturday
 
 
 def _as_aware_utc(dt: datetime) -> datetime:
@@ -16,13 +17,13 @@ def _as_aware_utc(dt: datetime) -> datetime:
 
 
 def is_submissions_closed(at: datetime | None = None) -> bool:
-    """True for the full local calendar day Tuesday or Saturday in US Eastern."""
+    """True for the full local calendar day on closed weekdays in US Eastern."""
     now = _as_aware_utc(at or datetime.now(timezone.utc))
     return now.astimezone(SUBMISSIONS_TZ).weekday() in CLOSED_WEEKDAYS
 
 
 def elapsed_open_hours(start: datetime, end: datetime | None = None) -> float:
-    """Hours between start and end that are not Tuesday or Saturday US Eastern."""
+    """Hours between start and end that are not on closed weekdays US Eastern."""
     start_utc = _as_aware_utc(start)
     end_utc = _as_aware_utc(end or datetime.now(timezone.utc))
     if end_utc <= start_utc:

--- a/cogs/lifecycle/submissions_gates.py
+++ b/cogs/lifecycle/submissions_gates.py
@@ -1,0 +1,71 @@
+"""Post gate open/close announcements in #submissions on closed weekdays."""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from typing import Any
+
+from discord.ext import commands
+
+import hc_constants
+from cogs.lifecycle.submissions_closed import CLOSED_WEEKDAYS, SUBMISSIONS_TZ
+from getters import getSubmissionsChannel
+
+GATES_CLOSED_MESSAGE = "THE GATES OF HELL ARE CLOSED"
+GATES_OPENED_MESSAGE = "THE GATES OF HELL HAVE OPENED"
+# Day after each closed day (Wed/Fri/Sun; Thursday included temporarily for testing).
+OPENED_WEEKDAYS = {2, 4, 6}
+
+
+def gate_announcement_for(at: datetime) -> str | None:
+    """Return announcement text for this US Eastern calendar day, if any."""
+    weekday = at.astimezone(SUBMISSIONS_TZ).weekday()
+    if weekday in CLOSED_WEEKDAYS:
+        return GATES_CLOSED_MESSAGE
+    if weekday in OPENED_WEEKDAYS:
+        return GATES_OPENED_MESSAGE
+    return None
+
+
+def gate_announcement_key(message: str, iso_date: str) -> str:
+    return f"{message}:{iso_date}"
+
+
+def _load_state() -> dict[str, Any]:
+    path = hc_constants.GATES_STATE_FILE
+    if not os.path.exists(path):
+        return {}
+    with open(path, "r", encoding="utf-8") as file:
+        content = file.read().strip()
+        if not content:
+            return {}
+        return json.loads(content)
+
+
+def _save_state(state: dict[str, Any]) -> None:
+    with open(hc_constants.GATES_STATE_FILE, "w", encoding="utf-8") as file:
+        json.dump(state, file)
+
+
+async def ensure_submissions_gates(bot: commands.Bot) -> None:
+    """Post today's gate message once per lifecycle day (closed/open transition days)."""
+    now = datetime.now(timezone.utc)
+    local = now.astimezone(SUBMISSIONS_TZ)
+    message = gate_announcement_for(now)
+    if message is None:
+        return
+
+    iso_today = local.date().isoformat()
+    key = gate_announcement_key(message, iso_today)
+    state = _load_state()
+    if state.get("last_announcement") == key:
+        return
+
+    channel = getSubmissionsChannel(bot)
+    await channel.send(message)
+    admin = await bot.fetch_user(hc_constants.LLLLLL)
+    await admin.send(message)
+    state["last_announcement"] = key
+    _save_state(state)

--- a/docs/card-flows/background.md
+++ b/docs/card-flows/background.md
@@ -10,7 +10,8 @@ Runs every 5 minutes. No idea which timezone the instance runs on.
 flowchart TD
   LOOP["Every 5 minutes"] --> R1["Reset submission cooldowns<br/>(#submissions skips Tue/Sat Eastern)"]
   R1 --> R2["Ensure submissions day marker"]
-  R2 --> R3["Check standard submissions"]
+  R2 --> R2B["Ensure submissions gate announcements"]
+  R2B --> R3["Check standard submissions"]
   R3 --> R4["Check masterpiece submissions"]
   R4 --> R5["Check token submissions"]
   R5 --> R6["Cross-post Reddit posts"]
@@ -32,7 +33,9 @@ Flag `REDDIT_COTD_VIA_DEVVIT=1` skips the hour-10 branch here; Devvit scheduler 
 
 ## Reddit → Discord
 
-Cron: `check_reddit` every 5 minutes (see lifecycle loop above).
+`check_reddit` every 5 minutes when `REDDIT_MIRROR_VIA_DEVVIT` is off (see lifecycle loop above).
+
+When `REDDIT_MIRROR_VIA_DEVVIT=1`, hellscube-bridge `PostSubmit` mirrors instead (see [`docs/hellscube-bridge/mirror.md`](../hellscube-bridge/mirror.md)).
 
 **Inbound flairs** (posts matching any of these are cross-posted to `#reddit`):
 

--- a/docs/card-flows/submissions.md
+++ b/docs/card-flows/submissions.md
@@ -6,14 +6,14 @@
 
 **Entry:** `#submissions` · background check every 5 min · `!wait` for cooldown
 
-Closed all day **Tuesday and Saturday** in US Eastern (`America/New_York`, EST/EDT). Those days do not count toward the 22h cooldown. `#pause-projects` and other intake channels stay open.
+Closed all day **Tuesday, Thursday, and Saturday** in US Eastern (`America/New_York`, EST/EDT). Thursday is included temporarily for testing. Those days do not count toward the 22h cooldown. `#pause-projects` and other intake channels stay open.
 
 ### Happy path
 
 ```mermaid
 flowchart TD
   U["User: CardName by @author(s) + image attachment"] --> CLOSED{"Tue or Sat<br/>US Eastern?"}
-  CLOSED -->|yes| CLOSED_MSG["#submissions-discussion:<br/>It is closed<br/>Post deleted · cooldown NOT consumed<br/>wait clock paused"]
+  CLOSED -->|yes| CLOSED_MSG["Post deleted<br/>DM admin · cooldown NOT consumed<br/>wait clock paused"]
   CLOSED -->|no| ATT{"Any attachment?"}
   ATT -->|no| MISS["Silent ignore — see validation"]
   ATT -->|yes| PING{"@ in card title?"}
@@ -52,7 +52,7 @@ flowchart TD
 ```mermaid
 flowchart TD
   POST["User posts in #submissions"] --> CLOSED{"Tue or Sat<br/>US Eastern?"}
-  CLOSED -->|yes| CL["#submissions-discussion: It is closed<br/>Post deleted · cooldown NOT consumed"]
+  CLOSED -->|yes| CL["Post deleted · DM admin<br/>cooldown NOT consumed"]
   CLOSED -->|no| A{"Any attachment?"}
 
   A -->|no| MI["Missing image<br/>No bot reply<br/>Post stays in channel<br/>Cooldown NOT consumed"]
@@ -67,7 +67,7 @@ flowchart TD
 
 | Case                     | Trigger                           | Bot response                                 | User post                  | Cooldown       |
 | ------------------------ | --------------------------------- | -------------------------------------------- | -------------------------- | -------------- |
-| **Closed day**           | Tuesday or Saturday, US Eastern   | `#submissions-discussion`: `It is closed`    | Deleted                    | Not written; clock paused |
+| **Closed day**           | Tuesday, Thursday, or Saturday, US Eastern | DM admin; post deleted                       | Deleted                    | Not written; clock paused |
 | **Missing image**        | No attachment                     | None (silent ignore)                         | **Kept** in `#submissions` | Not written    |
 | **Missing card name**    | Attachment present, empty/whitespace first line | `#submissions-discussion`: include card name + image returned | Deleted                    | Not written    |
 | **`@` in title**         | `@` in first line                 | DM: no `@` allowed                           | Kept                       | Not written    |
@@ -75,11 +75,11 @@ flowchart TD
 | **Non-image attachment** | e.g. PDF attached                 | Poll created anyway                          | Deleted (reposted as poll) | Consumed       |
 | **Magic skip**           | 1/4001 roll                       | Straight to veto (no poll)                   | Deleted                    | Consumed       |
 
-**Closed day:** Checked first. Any user post in `#submissions` on Tuesday or Saturday (US Eastern) is deleted and pinged in `#submissions-discussion` with `It is closed`. Cooldown timestamps are not written, and elapsed wait time ignores those days.
+**Closed day:** Checked first. Any user post in `#submissions` on Tuesday, Thursday, or Saturday (US Eastern) is deleted and the admin is DM'd. Cooldown timestamps are not written, and elapsed wait time ignores those days. Mork posts `THE GATES OF HELL ARE CLOSED` in `#submissions` (and DMs the admin) at the start of each closed day and `THE GATES OF HELL HAVE OPENED` at the start of Wednesday, Friday, and Sunday (US Eastern).
 
 **Missing name:** Intake bails before cooldown write or repost. The card image is reattached in `#submissions-discussion` so the user can fix the title and resubmit. Whitespace-only first lines count as missing.
 
-**Missing image:** Intake bails before cooldown, name checks, or repost. Text-only posts stay in channel with no ping to attach an image. Open days only; closed days delete the post and ping instead.
+**Missing image:** Intake bails before cooldown, name checks, or repost. Text-only posts stay in channel with no ping to attach an image. Open days only; closed days delete the post and DM the admin instead.
 
 **Image detection elsewhere:** Day markers and the daily submissions gallery only count messages whose first attachment is an image (`image/*` content type or `.png` / `.jpg` / `.jpeg` / `.gif` / `.webp` / `.bmp`). That filter does not apply at initial `#submissions` intake.
 

--- a/hc_constants.py
+++ b/hc_constants.py
@@ -55,6 +55,7 @@ PREVIOUS_WEEK_PIN_PREFIX = "PREVIOUS WEEK"
 MASTERPIECE_THRESHOLD = 45
 SUBMISSIONS_STATE_FILE = "../mork-state"
 MASTERPIECE_STATE_FILE = "../mork-masterpiece-state"
+GATES_STATE_FILE = "../mork-gates-state"
 VC_THRESHOLD = 5
 
 # Errata channel: if upvotes - downvotes >= this, add checkmark and post to veto-polls.

--- a/scripts/test_submissions_closed.py
+++ b/scripts/test_submissions_closed.py
@@ -12,12 +12,18 @@ from cogs.lifecycle.submissions_closed import (  # noqa: E402
     elapsed_open_hours,
     is_submissions_closed,
 )
+from cogs.lifecycle.submissions_gates import (  # noqa: E402
+    GATES_CLOSED_MESSAGE,
+    GATES_OPENED_MESSAGE,
+    gate_announcement_for,
+)
 
 NY = ZoneInfo("America/New_York")
 
 
 def test_closed_weekdays():
     assert is_submissions_closed(datetime(2026, 8, 18, 15, 0, tzinfo=NY))  # Tuesday
+    assert is_submissions_closed(datetime(2026, 8, 20, 15, 0, tzinfo=NY))  # Thursday
     assert is_submissions_closed(datetime(2026, 8, 15, 0, 0, tzinfo=NY))  # Saturday
     assert is_submissions_closed(datetime(2026, 8, 15, 23, 59, tzinfo=NY))
     assert not is_submissions_closed(datetime(2026, 8, 17, 15, 0, tzinfo=NY))  # Monday
@@ -57,6 +63,24 @@ def test_elapsed_zero_when_end_before_start():
     assert elapsed_open_hours(start, end) == 0.0
 
 
+def test_gate_announcements():
+    tue = datetime(2026, 8, 18, 12, 0, tzinfo=NY)
+    thu = datetime(2026, 8, 20, 12, 0, tzinfo=NY)
+    sat = datetime(2026, 8, 15, 12, 0, tzinfo=NY)
+    wed = datetime(2026, 8, 19, 12, 0, tzinfo=NY)
+    fri = datetime(2026, 8, 21, 12, 0, tzinfo=NY)
+    sun = datetime(2026, 8, 16, 12, 0, tzinfo=NY)
+    mon = datetime(2026, 8, 17, 12, 0, tzinfo=NY)
+
+    assert gate_announcement_for(tue) == GATES_CLOSED_MESSAGE
+    assert gate_announcement_for(thu) == GATES_CLOSED_MESSAGE
+    assert gate_announcement_for(sat) == GATES_CLOSED_MESSAGE
+    assert gate_announcement_for(wed) == GATES_OPENED_MESSAGE
+    assert gate_announcement_for(fri) == GATES_OPENED_MESSAGE
+    assert gate_announcement_for(sun) == GATES_OPENED_MESSAGE
+    assert gate_announcement_for(mon) is None
+
+
 if __name__ == "__main__":
     test_closed_weekdays()
     test_closed_uses_eastern_not_utc()
@@ -64,4 +88,5 @@ if __name__ == "__main__":
     test_elapsed_skips_tuesday_for_cooldown()
     test_elapsed_open_weekday_is_wall_clock()
     test_elapsed_zero_when_end_before_start()
+    test_gate_announcements()
     print("ok")


### PR DESCRIPTION
## Summary
- Post `THE GATES OF HELL ARE CLOSED` / `THE GATES OF HELL HAVE OPENED` in `#submissions` at the start of closed/open transition days (US Eastern)
- DM LLLLLL the same gate messages for testing
- On closed days, delete user posts and DM LLLLLL instead of pinging `#submissions-discussion`
- Temporarily include Thursday as a closed day for testing (with Friday as the reopen announcement)

## Test plan
- [ ] On a closed day (Tue/Thu/Sat ET), posting in `#submissions` deletes the post and DMs LLLLLL
- [ ] Lifecycle posts gate closed/open messages in `#submissions` and DMs LLLLLL once per transition day
- [ ] `python scripts/test_submissions_closed.py` passes


Made with [Cursor](https://cursor.com)