### PR TITLE
Define reddit_mirror_via_devvit_enabled so Mork can boot

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -25,3 +25,6 @@ REDDIT_USER_AGENT=your_user_agent_string
 # Card of the day via Devvit scheduler (on for current deploy)
 REDDIT_COTD_VIA_DEVVIT=1
 # hellscube-bridge global setting cardOfTheDayViaDevvit defaults true in devvit.json
+
+# Reddit → Discord mirror via Devvit PostSubmit (off; Mork check_reddit remains default)
+# REDDIT_MIRROR_VIA_DEVVIT=1

--- a/reddit_devvit.py
+++ b/reddit_devvit.py
@@ -27,6 +27,15 @@ def reddit_cotd_via_devvit_enabled() -> bool:
     }
 
 
+def reddit_mirror_via_devvit_enabled() -> bool:
+    """When true, Reddit → Discord mirroring is handled by hellscube-bridge PostSubmit (not check_reddit)."""
+    return os.environ.get("REDDIT_MIRROR_VIA_DEVVIT", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+    }
+
+
 def reddit_title_for_acceptance(
     card_message: str,
     set_id: str,

--- a/scripts/test_reddit_devvit.py
+++ b/scripts/test_reddit_devvit.py
@@ -6,6 +6,7 @@ from reddit_devvit import (
     post_accept_via_devvit,
     reddit_accept_via_devvit_enabled,
     reddit_cotd_via_devvit_enabled,
+    reddit_mirror_via_devvit_enabled,
     reddit_title_for_acceptance,
 )
 
@@ -22,6 +23,14 @@ class RedditDevvitTests(unittest.TestCase):
             self.assertTrue(reddit_cotd_via_devvit_enabled())
         with patch.dict(os.environ, {"REDDIT_COTD_VIA_DEVVIT": "0"}, clear=False):
             self.assertFalse(reddit_cotd_via_devvit_enabled())
+
+    def test_mirror_feature_flag(self):
+        with patch.dict(os.environ, {"REDDIT_MIRROR_VIA_DEVVIT": "1"}, clear=False):
+            self.assertTrue(reddit_mirror_via_devvit_enabled())
+        with patch.dict(os.environ, {"REDDIT_MIRROR_VIA_DEVVIT": "0"}, clear=False):
+            self.assertFalse(reddit_mirror_via_devvit_enabled())
+        with patch.dict(os.environ, {"REDDIT_MIRROR_VIA_DEVVIT": ""}, clear=False):
+            self.assertFalse(reddit_mirror_via_devvit_enabled())
 
     def test_title_uses_set_id(self):
         title = reddit_title_for_acceptance(


### PR DESCRIPTION
## Summary
- Lifecycle already imported `reddit_mirror_via_devvit_enabled`, but `reddit_devvit.py` never defined it, so cog load failed and systemd restart-looped.
- Add the helper (defaults off, so `check_reddit` keeps running) plus a unit test and env template comment.

## Test plan
- [x] `python -m unittest scripts.test_reddit_devvit`
- [ ] Deploy to lil-mork and confirm `systemctl is-active mork` stays active
- [ ] Confirm Discord bot comes back online


Made with [Cursor](https://cursor.com)