### PR TITLE
Fix database_cache imports for HellscubeDatabase startup

### DIFF
--- a/database_cache/database.py
+++ b/database_cache/database.py
@@ -1,9 +1,9 @@
 from dataclasses import dataclass
 from typing import Any
 
-from database_utils import fixName
-from get_closest_name import get_closest_name
-from setHandling import splitCardName
+from database_cache.database_utils import fixName
+from database_cache.get_closest_name import get_closest_name
+from database_cache.setHandling import splitCardName
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- Fix `database_cache/database.py` to use package-qualified imports instead of bare sibling imports.
- Resolves `ModuleNotFoundError: No module named 'database_utils'` when loading `cogs.HellscubeDatabase` on the VM.

## Test plan
- [x] `python3 -c "from database_cache.database import build_database"` succeeds from repo root
- [ ] Deploy to `lil-mork` and confirm bot starts without `ExtensionFailed` on `cogs.HellscubeDatabase`


Made with [Cursor](https://cursor.com)